### PR TITLE
Refactor fully-qualified type name building into its own internal package.

### DIFF
--- a/internal/typename/ginkgo_test.go
+++ b/internal/typename/ginkgo_test.go
@@ -1,0 +1,15 @@
+package typename_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/internal/typename/typename.go
+++ b/internal/typename/typename.go
@@ -1,0 +1,152 @@
+package typename
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Of returns the fully-qualified name of the given type.
+//
+// The return value is similar to the string returned by ReflectType.String()
+// but shows fully-qualified package paths, not just package names.
+func Of(rt reflect.Type) string {
+	if rt.Name() != "" {
+		return buildDefinedName(rt)
+	}
+
+	// only the "composite" types can be unnabled:
+	switch rt.Kind() {
+	case reflect.Ptr:
+		return fmt.Sprintf("*%s", Of(rt.Elem()))
+	case reflect.Slice:
+		return fmt.Sprintf("[]%s", Of(rt.Elem()))
+	case reflect.Array:
+		return fmt.Sprintf("[%d]%s", rt.Len(), Of(rt.Elem()))
+	case reflect.Map:
+		return fmt.Sprintf("map[%s]%s", Of(rt.Key()), Of(rt.Elem()))
+	case reflect.Chan:
+		return buildChanName(rt)
+	case reflect.Interface:
+		return buildInterfaceName(rt)
+	case reflect.Struct:
+		return buildStructName(rt)
+	default: // reflect.Func
+		return "func" + buildFuncSignature(rt)
+	}
+}
+
+func buildDefinedName(rt reflect.Type) string {
+	var name string
+
+	if p := rt.PkgPath(); p != "" {
+		name += p
+		name += `.`
+	}
+
+	return name + rt.Name()
+}
+
+func buildChanName(rt reflect.Type) string {
+	elem := Of(rt.Elem())
+
+	switch rt.ChanDir() {
+	case reflect.RecvDir: // <-chan
+		return "<-chan " + elem
+	case reflect.SendDir: // chan<-
+		return "chan<- " + elem
+	default:
+		return "chan " + elem
+	}
+}
+
+func buildInterfaceName(rt reflect.Type) string {
+	name := "interface {"
+
+	n := rt.NumMethod()
+
+	if n > 0 {
+		name += " "
+
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				name += "; "
+			}
+
+			m := rt.Method(i)
+
+			name += m.Name
+			name += buildFuncSignature(m.Type)
+		}
+
+		name += " "
+	}
+
+	name += "}"
+
+	return name
+}
+
+func buildStructName(rt reflect.Type) string {
+	name := "struct {"
+
+	n := rt.NumField()
+
+	if n > 0 {
+		name += " "
+
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				name += "; "
+			}
+
+			f := rt.Field(i)
+
+			if !f.Anonymous {
+				name += f.Name
+				name += " "
+			}
+
+			name += Of(f.Type)
+		}
+
+		name += " "
+	}
+
+	name += "}"
+
+	return name
+}
+
+func buildFuncSignature(rt reflect.Type) string {
+	name := "("
+	for i := 0; i < rt.NumIn(); i++ {
+		if i > 0 {
+			name += ", "
+		}
+
+		name += Of(rt.In(i))
+	}
+	name += ")"
+
+	if n := rt.NumOut(); n != 0 {
+		name += " "
+
+		if n > 1 {
+			name += "("
+		}
+
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				name += ", "
+			}
+
+			name += Of(rt.Out(i))
+		}
+
+		if n > 1 {
+			name += ")"
+		}
+	}
+
+	return name
+}

--- a/internal/typename/typename_test.go
+++ b/internal/typename/typename_test.go
@@ -1,0 +1,139 @@
+package typename_test
+
+import (
+	"reflect"
+	"strings"
+
+	. "github.com/dogmatiq/configkit/internal/typename"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+type testType struct{}
+
+var _ = Describe("func Of()", func() {
+	DescribeTable(
+		"it returns the expected name",
+		func(expect string, rt reflect.Type) {
+			n := Of(rt)
+			Expect(n).To(Equal(expect))
+
+			// verify that the result is similar to ReflectType.String()
+			s := strings.ReplaceAll(n, "github.com/dogmatiq/configkit/internal/", "")
+			Expect(s).To(Equal(rt.String()))
+		},
+		Entry(
+			"user-defined type",
+			"github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf(testType{}),
+		),
+		Entry(
+			"basic type",
+			"string",
+			reflect.TypeOf(""),
+		),
+		Entry(
+			"pointer",
+			"*github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf(&testType{}),
+		),
+		Entry(
+			"slice",
+			"[]github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf([]testType{}),
+		),
+		Entry(
+			"array",
+			"[5]github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf([5]testType{}),
+		),
+		Entry(
+			"map",
+			"map[int]github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf(map[int]testType{}),
+		),
+		Entry(
+			"channel",
+			"chan github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf((chan testType)(nil)),
+		),
+		Entry(
+			"recv-only channel",
+			"<-chan github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf((<-chan testType)(nil)),
+		),
+		Entry(
+			"send-only channel",
+			"chan<- github.com/dogmatiq/configkit/internal/typename_test.testType",
+			reflect.TypeOf((chan<- testType)(nil)),
+		),
+		Entry(
+			"empty interface",
+			"interface {}",
+			reflect.TypeOf((*interface{})(nil)).Elem(),
+		),
+		Entry(
+			"interface w/ single method",
+			"interface { Foo() }",
+			reflect.TypeOf((*interface {
+				Foo()
+			})(nil)).Elem(),
+		),
+		Entry(
+			"interface w/ multiple methods",
+			"interface { Bar(); Foo() }",
+			reflect.TypeOf((*interface {
+				Foo()
+				Bar()
+			})(nil)).Elem(),
+		),
+		Entry(
+			"empty struct",
+			"struct {}",
+			reflect.TypeOf(struct{}{}),
+		),
+		Entry(
+			"struct w/ single field",
+			"struct { F1 github.com/dogmatiq/configkit/internal/typename_test.testType }",
+			reflect.TypeOf(struct {
+				F1 testType
+			}{}),
+		),
+		Entry(
+			"struct w/ multiple fields",
+			"struct { F1 int; F2 github.com/dogmatiq/configkit/internal/typename_test.testType }",
+			reflect.TypeOf(struct {
+				F1 int
+				F2 testType
+			}{}),
+		),
+		Entry(
+			"struct w/ embedded type",
+			"struct { github.com/dogmatiq/configkit/internal/typename_test.testType }",
+			reflect.TypeOf(struct {
+				testType
+			}{}),
+		),
+		Entry(
+			"nullary func",
+			"func()",
+			reflect.TypeOf(func() {}),
+		),
+		Entry(
+			"func w/ multiple intput parameters",
+			"func(int, github.com/dogmatiq/configkit/internal/typename_test.testType)",
+			reflect.TypeOf(func(int, testType) {}),
+		),
+		Entry(
+			"func w/ single output parameter",
+			"func(github.com/dogmatiq/configkit/internal/typename_test.testType) error",
+			reflect.TypeOf(func(testType) error { return nil }),
+		),
+		Entry(
+			"func w/ multiple output parameters",
+			"func(github.com/dogmatiq/configkit/internal/typename_test.testType) (bool, error)",
+			reflect.TypeOf(func(testType) (bool, error) { return true, nil }),
+		),
+	)
+})

--- a/message/name.go
+++ b/message/name.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/dogmatiq/configkit/internal/typename"
 	"github.com/dogmatiq/dogma"
 )
 
@@ -32,7 +33,7 @@ type Name struct {
 // NameOf returns the fully-qualified type name of v.
 func NameOf(v dogma.Message) Name {
 	rt := reflect.TypeOf(v)
-	n := buildName(rt, true)
+	n := typename.Of(rt)
 	return Name{n}
 }
 
@@ -73,124 +74,4 @@ func (n Name) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary unmarshals a type from its binary representation.
 func (n *Name) UnmarshalBinary(data []byte) error {
 	return n.UnmarshalText(data)
-}
-
-// buildName returns the name of the given type.
-//
-// If qual is true, it produces package-path-qualified names.
-// It panics if rt does not implement dogma.Message.
-func buildName(rt reflect.Type, qual bool) string {
-	// This is a static assertion that the dogma.Message interface is empty. If
-	// this fails to compile, additional logic must be added to verify that rt
-	// truly does implement dogma.Message.
-	var _ dogma.Message = (interface{})(nil)
-
-	if rt.Name() != "" {
-		return buildDefinedName(rt, qual)
-	}
-
-	switch rt.Kind() {
-	case reflect.Ptr:
-		return fmt.Sprintf("*%s", buildName(rt.Elem(), qual))
-	case reflect.Slice:
-		return fmt.Sprintf("[]%s", buildName(rt.Elem(), qual))
-	case reflect.Array:
-		return fmt.Sprintf("[%d]%s", rt.Len(), buildName(rt.Elem(), qual))
-	case reflect.Map:
-		return fmt.Sprintf("map[%s]%s", buildName(rt.Key(), qual), buildName(rt.Elem(), qual))
-	case reflect.Chan:
-		return buildChanName(rt, qual)
-	case reflect.Struct:
-		return buildStructName(rt, qual)
-	case reflect.Func:
-		return buildFuncName(rt, qual)
-	}
-
-	// CODE COVERAGE: Type is likely an interface. This path is unreachable
-	// using the public API.
-	panic("unsupported type: " + rt.String())
-}
-
-func buildDefinedName(rt reflect.Type, qual bool) string {
-	if !qual {
-		return rt.String()
-	}
-
-	var name string
-
-	if p := rt.PkgPath(); p != "" {
-		name += p
-		name += `.`
-	}
-
-	return name + rt.Name()
-}
-
-func buildChanName(rt reflect.Type, qual bool) string {
-	elem := buildName(rt.Elem(), qual)
-
-	switch rt.ChanDir() {
-	case reflect.RecvDir: // <-chan
-		return "<-chan " + elem
-	case reflect.SendDir: // chan<-
-		return "chan<- " + elem
-	default:
-		return "chan " + elem
-	}
-}
-
-func buildStructName(rt reflect.Type, qual bool) string {
-	name := "struct {"
-
-	for i := 0; i < rt.NumField(); i++ {
-		if i > 0 {
-			name += "; "
-		}
-
-		f := rt.Field(i)
-		name += f.Name
-
-		if !f.Anonymous {
-			name += " "
-			name += buildName(f.Type, qual)
-		}
-	}
-
-	name += "}"
-
-	return name
-}
-
-func buildFuncName(rt reflect.Type, qual bool) string {
-	name := "func("
-	for i := 0; i < rt.NumIn(); i++ {
-		if i > 0 {
-			name += ", "
-		}
-
-		name += buildName(rt.In(i), qual)
-	}
-	name += ")"
-
-	if n := rt.NumOut(); n != 0 {
-		name += " "
-
-		if n > 1 {
-			name += "("
-		}
-
-		for i := 0; i < n; i++ {
-			if i > 0 {
-				name += ", "
-			}
-
-			name += buildName(rt.Out(i), qual)
-		}
-
-		if n > 1 {
-			name += ")"
-		}
-	}
-
-	return name
 }

--- a/message/name_test.go
+++ b/message/name_test.go
@@ -2,119 +2,17 @@ package message_test
 
 import (
 	. "github.com/dogmatiq/configkit/message"
-	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("type Name", func() {
 	Describe("func NameOf()", func() {
-		DescribeTable(
-			"it returns the expected name",
-			func(expect string, v dogma.Message) {
-				n := NameOf(v)
-				Expect(n.String()).To(Equal(expect))
-			},
-			Entry(
-				"user-defined type",
-				"github.com/dogmatiq/dogma/fixtures.MessageA",
-				fixtures.MessageA1,
-			),
-			Entry(
-				"basic type",
-				"string",
-				string(""),
-			),
-			Entry(
-				"pointer",
-				"*github.com/dogmatiq/dogma/fixtures.MessageA",
-				(*fixtures.MessageA)(nil),
-			),
-			Entry(
-				"slice",
-				"[]github.com/dogmatiq/dogma/fixtures.MessageA",
-				[]fixtures.MessageA{},
-			),
-			Entry(
-				"array",
-				"[5]github.com/dogmatiq/dogma/fixtures.MessageA",
-				[5]fixtures.MessageA{},
-			),
-			Entry(
-				"map",
-				"map[int]github.com/dogmatiq/dogma/fixtures.MessageA",
-				map[int]fixtures.MessageA{},
-			),
-			Entry(
-				"channel",
-				"chan github.com/dogmatiq/dogma/fixtures.MessageA",
-				(chan fixtures.MessageA)(nil),
-			),
-			Entry(
-				"recv-only channel",
-				"<-chan github.com/dogmatiq/dogma/fixtures.MessageA",
-				(<-chan fixtures.MessageA)(nil),
-			),
-			Entry(
-				"send-only channel",
-				"chan<- github.com/dogmatiq/dogma/fixtures.MessageA",
-				(chan<- fixtures.MessageA)(nil),
-			),
-			Entry(
-				"empty struct",
-				"struct {}",
-				struct{}{},
-			),
-			Entry(
-				"struct w/ single field",
-				"struct {F1 github.com/dogmatiq/dogma/fixtures.MessageA}",
-				struct {
-					F1 fixtures.MessageA
-				}{},
-			),
-			Entry(
-				"struct w/ multiple fields",
-				"struct {F1 int; F2 github.com/dogmatiq/dogma/fixtures.MessageA}",
-				struct {
-					F1 int
-					F2 fixtures.MessageA
-				}{},
-			),
-			Entry(
-				"struct w/ embedded field",
-				"struct {MessageA}",
-				struct {
-					fixtures.MessageA
-				}{},
-			),
-			Entry(
-				"nullary func",
-				"func()",
-				(func())(nil),
-			),
-			Entry(
-				"func w/ multiple intput parameters",
-				"func(int, github.com/dogmatiq/dogma/fixtures.MessageA)",
-				(func(int, fixtures.MessageA))(nil),
-			),
-			Entry(
-				"func w/ single output parameter",
-				"func(github.com/dogmatiq/dogma/fixtures.MessageA) error",
-				(func(fixtures.MessageA) error)(nil),
-			),
-			Entry(
-				"func w/ single output parameter",
-				"func(github.com/dogmatiq/dogma/fixtures.MessageA) error",
-				(func(fixtures.MessageA) error)(nil),
-			),
-			Entry(
-				"func w/ multiple output parameters",
-				"func(github.com/dogmatiq/dogma/fixtures.MessageA) (bool, error)",
-				(func(fixtures.MessageA) (bool, error))(nil),
-			),
-		)
+		It("returns the fully-qualified name", func() {
+			n := NameOf(fixtures.MessageA1)
+			Expect(n.String()).To(Equal("github.com/dogmatiq/dogma/fixtures.MessageA"))
+		})
 	})
 
 	Describe("func MarshalText()", func() {

--- a/message/type.go
+++ b/message/type.go
@@ -3,6 +3,7 @@ package message
 import (
 	"reflect"
 
+	"github.com/dogmatiq/configkit/internal/typename"
 	"github.com/dogmatiq/dogma"
 )
 
@@ -32,7 +33,7 @@ type Type struct {
 // TypeOf returns the message type of m.
 func TypeOf(m dogma.Message) Type {
 	rt := reflect.TypeOf(m)
-	n := buildName(rt, true)
+	n := typename.Of(rt)
 
 	return Type{
 		Name{n},
@@ -66,7 +67,7 @@ func (t Type) ReflectType() reflect.Type {
 //
 // The returned name is not necessarily globally-unique.
 func (t Type) String() string {
-	return buildName(t.rt, false)
+	return t.rt.String()
 }
 
 // IsZero returns true if t is the zero-value.

--- a/message/type_test.go
+++ b/message/type_test.go
@@ -3,12 +3,9 @@ package message_test
 import (
 	"reflect"
 
-	"github.com/dogmatiq/dogma"
-
 	. "github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -48,109 +45,9 @@ var _ = Describe("type Type", func() {
 	})
 
 	Describe("func String()", func() {
-		DescribeTable(
-			"it returns the expected short representation",
-			func(expect string, v dogma.Message) {
-				t := TypeOf(v)
-				Expect(t.String()).To(Equal(expect))
-			},
-			Entry(
-				"user-defined type",
-				"fixtures.MessageA",
-				fixtures.MessageA1,
-			),
-			Entry(
-				"basic type",
-				"string",
-				"",
-			),
-			Entry(
-				"pointer",
-				"*fixtures.MessageA",
-				(*fixtures.MessageA)(nil),
-			),
-			Entry(
-				"slice",
-				"[]fixtures.MessageA",
-				[]fixtures.MessageA{},
-			),
-			Entry(
-				"array",
-				"[5]fixtures.MessageA",
-				[5]fixtures.MessageA{},
-			),
-			Entry(
-				"map",
-				"map[int]fixtures.MessageA",
-				map[int]fixtures.MessageA{},
-			),
-			Entry(
-				"channel",
-				"chan fixtures.MessageA",
-				(chan fixtures.MessageA)(nil),
-			),
-			Entry(
-				"recv-only channel",
-				"<-chan fixtures.MessageA",
-				(<-chan fixtures.MessageA)(nil),
-			),
-			Entry(
-				"send-only channel",
-				"chan<- fixtures.MessageA",
-				(chan<- fixtures.MessageA)(nil),
-			),
-			Entry(
-				"empty struct",
-				"struct {}",
-				struct{}{},
-			),
-			Entry(
-				"struct w/ single field",
-				"struct {F1 fixtures.MessageA}",
-				struct {
-					F1 fixtures.MessageA
-				}{},
-			),
-			Entry(
-				"struct w/ multiple fields",
-				"struct {F1 int; F2 fixtures.MessageA}",
-				struct {
-					F1 int
-					F2 fixtures.MessageA
-				}{},
-			),
-			Entry(
-				"struct w/ embedded field",
-				"struct {MessageA}",
-				struct {
-					fixtures.MessageA
-				}{},
-			),
-			Entry(
-				"nullary func",
-				"func()",
-				(func())(nil),
-			),
-			Entry(
-				"func w/ multiple intput parameters",
-				"func(int, fixtures.MessageA)",
-				(func(int, fixtures.MessageA))(nil),
-			),
-			Entry(
-				"func w/ single output parameter",
-				"func(fixtures.MessageA) error",
-				(func(fixtures.MessageA) error)(nil),
-			),
-			Entry(
-				"func w/ single output parameter",
-				"func(fixtures.MessageA) error",
-				(func(fixtures.MessageA) error)(nil),
-			),
-			Entry(
-				"func w/ multiple output parameters",
-				"func(fixtures.MessageA) (bool, error)",
-				(func(fixtures.MessageA) (bool, error))(nil),
-			),
-		)
+		It("returns the string representation of the type", func() {
+			t := TypeOf(fixtures.MessageA1)
+			Expect(t.String()).To(Equal("fixtures.MessageA"))
+		})
 	})
 })


### PR DESCRIPTION
This allows it to be used for any Go type, not just implementations of `dogma.Message`.