### PR TITLE
Implement application configurations.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -37,7 +37,7 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 
 	c := &handlerConfigurer{
 		entityConfigurer: entityConfigurer{
-			target: &cfg.entity,
+			entity: &cfg.entity,
 		},
 	}
 

--- a/application.go
+++ b/application.go
@@ -60,6 +60,7 @@ func FromApplication(a dogma.Application) RichApplication {
 		entityConfigurer: entityConfigurer{
 			target: &cfg.entity,
 		},
+		target: cfg,
 	}
 
 	a.Configure(c)
@@ -72,7 +73,9 @@ func FromApplication(a dogma.Application) RichApplication {
 type application struct {
 	entity
 
-	impl dogma.Application
+	handlers     HandlerSet
+	richHandlers RichHandlerSet
+	impl         dogma.Application
 }
 
 func (a *application) AcceptVisitor(ctx context.Context, v Visitor) error {
@@ -84,11 +87,11 @@ func (a *application) AcceptRichVisitor(ctx context.Context, v RichVisitor) erro
 }
 
 func (a *application) Handlers() HandlerSet {
-	return nil
+	return a.handlers
 }
 
 func (a *application) RichHandlers() RichHandlerSet {
-	return nil
+	return a.richHandlers
 }
 
 func (a *application) ForeignMessageNames() message.NameRoles {

--- a/application.go
+++ b/application.go
@@ -58,7 +58,7 @@ func FromApplication(a dogma.Application) RichApplication {
 
 	c := &applicationConfigurer{
 		entityConfigurer: entityConfigurer{
-			target: &cfg.entity,
+			entity: &cfg.entity,
 		},
 		target: cfg,
 	}

--- a/application.go
+++ b/application.go
@@ -70,6 +70,7 @@ func FromApplication(a dogma.Application) RichApplication {
 	return cfg
 }
 
+// application is an implementation of RichApplication.
 type application struct {
 	entity
 

--- a/application.go
+++ b/application.go
@@ -1,6 +1,9 @@
 package configkit
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 )
@@ -39,4 +42,63 @@ type RichApplication interface {
 
 	// Application returns the underlying application.
 	Application() dogma.Application
+}
+
+// FromApplication returns the configuration for an application.
+//
+// It panics if the application is configured incorrectly. Use Recover() to
+// convert configuration related panic values to errors.
+func FromApplication(a dogma.Application) RichApplication {
+	cfg := &application{
+		entity: entity{
+			rt: reflect.TypeOf(a),
+		},
+		impl: a,
+	}
+
+	c := &applicationConfigurer{
+		entityConfigurer: entityConfigurer{
+			target: &cfg.entity,
+		},
+	}
+
+	a.Configure(c)
+
+	c.validate()
+
+	return cfg
+}
+
+type application struct {
+	entity
+
+	impl dogma.Application
+}
+
+func (a *application) AcceptVisitor(ctx context.Context, v Visitor) error {
+	return v.VisitApplication(ctx, a)
+}
+
+func (a *application) AcceptRichVisitor(ctx context.Context, v RichVisitor) error {
+	return v.VisitRichApplication(ctx, a)
+}
+
+func (a *application) Handlers() HandlerSet {
+	return nil
+}
+
+func (a *application) RichHandlers() RichHandlerSet {
+	return nil
+}
+
+func (a *application) ForeignMessageNames() message.NameRoles {
+	return nil
+}
+
+func (a *application) ForeignMessageTypes() message.TypeRoles {
+	return nil
+}
+
+func (a *application) Application() dogma.Application {
+	return a.impl
 }

--- a/application.go
+++ b/application.go
@@ -60,7 +60,7 @@ func FromApplication(a dogma.Application) RichApplication {
 		entityConfigurer: entityConfigurer{
 			entity: &cfg.entity,
 		},
-		target: cfg,
+		app: cfg,
 	}
 
 	a.Configure(c)
@@ -75,6 +75,8 @@ type application struct {
 
 	handlers     HandlerSet
 	richHandlers RichHandlerSet
+	foreignNames message.NameRoles
+	foreignTypes message.TypeRoles
 	impl         dogma.Application
 }
 
@@ -95,11 +97,11 @@ func (a *application) RichHandlers() RichHandlerSet {
 }
 
 func (a *application) ForeignMessageNames() message.NameRoles {
-	return nil
+	return a.foreignNames
 }
 
 func (a *application) ForeignMessageTypes() message.TypeRoles {
-	return nil
+	return a.foreignTypes
 }
 
 func (a *application) Application() dogma.Application {

--- a/application_test.go
+++ b/application_test.go
@@ -197,7 +197,7 @@ var _ = Describe("func FromApplication()", func() {
 			})
 		})
 
-		XDescribe("func Handlers()", func() {
+		Describe("func Handlers()", func() {
 			It("returns a set containing all handlers in the application", func() {
 				Expect(cfg.Handlers()).To(Equal(
 					NewHandlerSet(

--- a/application_test.go
+++ b/application_test.go
@@ -1,0 +1,617 @@
+package configkit_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	. "github.com/dogmatiq/configkit"
+	cfixtures "github.com/dogmatiq/configkit/fixtures" // can't dot-import due to conflicts
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func FromApplication()", func() {
+	var (
+		aggregate   *fixtures.AggregateMessageHandler
+		process     *fixtures.ProcessMessageHandler
+		integration *fixtures.IntegrationMessageHandler
+		projection  *fixtures.ProjectionMessageHandler
+		app         *fixtures.Application
+	)
+
+	BeforeEach(func() {
+		aggregate = &fixtures.AggregateMessageHandler{
+			ConfigureFunc: func(c dogma.AggregateConfigurer) {
+				c.Identity("<aggregate>", "<aggregate-key>")
+				c.ConsumesCommandType(fixtures.MessageA{})
+				c.ProducesEventType(fixtures.MessageE{})
+			},
+		}
+
+		process = &fixtures.ProcessMessageHandler{
+			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+				c.Identity("<process>", "<process-key>")
+				c.ConsumesEventType(fixtures.MessageB{})
+				c.ConsumesEventType(fixtures.MessageE{}) // shared with <projection>
+				c.ProducesCommandType(fixtures.MessageC{})
+				c.SchedulesTimeoutType(fixtures.MessageT{})
+			},
+		}
+
+		integration = &fixtures.IntegrationMessageHandler{
+			ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+				c.Identity("<integration>", "<integration-key>")
+				c.ConsumesCommandType(fixtures.MessageC{})
+				c.ProducesEventType(fixtures.MessageF{})
+			},
+		}
+
+		projection = &fixtures.ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				c.Identity("<projection>", "<projection-key>")
+				c.ConsumesEventType(fixtures.MessageD{})
+				c.ConsumesEventType(fixtures.MessageE{}) // shared with <process>
+			},
+		}
+
+		app = &fixtures.Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+				c.RegisterAggregate(aggregate)
+				c.RegisterProcess(process)
+				c.RegisterIntegration(integration)
+				c.RegisterProjection(projection)
+			},
+		}
+	})
+
+	When("the configuration is valid", func() {
+		var cfg RichApplication
+
+		BeforeEach(func() {
+			cfg = FromApplication(app)
+		})
+
+		Describe("func Identity()", func() {
+			It("returns the application identity", func() {
+				Expect(cfg.Identity()).To(Equal(
+					MustNewIdentity("<app>", "<app-key>"),
+				))
+			})
+		})
+
+		XDescribe("func MessageNames()", func() {
+			It("returns the expected message names", func() {
+				Expect(cfg.MessageNames()).To(Equal(
+					EntityMessageNames{
+						Roles: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+							cfixtures.MessageCTypeName: message.CommandRole,
+							cfixtures.MessageDTypeName: message.EventRole,
+							cfixtures.MessageETypeName: message.EventRole,
+							cfixtures.MessageFTypeName: message.EventRole,
+							cfixtures.MessageTTypeName: message.TimeoutRole,
+						},
+						Produced: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+							cfixtures.MessageCTypeName: message.CommandRole,
+							cfixtures.MessageDTypeName: message.EventRole,
+							cfixtures.MessageETypeName: message.EventRole,
+							cfixtures.MessageFTypeName: message.EventRole,
+							cfixtures.MessageTTypeName: message.TimeoutRole,
+						},
+						Consumed: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+							cfixtures.MessageCTypeName: message.CommandRole,
+							cfixtures.MessageDTypeName: message.EventRole,
+							cfixtures.MessageETypeName: message.EventRole,
+							cfixtures.MessageFTypeName: message.EventRole,
+							cfixtures.MessageTTypeName: message.TimeoutRole,
+						},
+					},
+				))
+			})
+		})
+
+		XDescribe("func MessageTypes()", func() {
+			It("returns the expected message types", func() {
+				Expect(cfg.MessageTypes()).To(Equal(
+					EntityMessageTypes{
+						Roles: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.EventRole,
+							cfixtures.MessageCType: message.CommandRole,
+							cfixtures.MessageDType: message.EventRole,
+							cfixtures.MessageEType: message.EventRole,
+							cfixtures.MessageFType: message.EventRole,
+							cfixtures.MessageTType: message.TimeoutRole,
+						},
+						Produced: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.EventRole,
+							cfixtures.MessageCType: message.CommandRole,
+							cfixtures.MessageDType: message.EventRole,
+							cfixtures.MessageEType: message.EventRole,
+							cfixtures.MessageFType: message.EventRole,
+							cfixtures.MessageTType: message.TimeoutRole,
+						},
+						Consumed: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.EventRole,
+							cfixtures.MessageCType: message.CommandRole,
+							cfixtures.MessageDType: message.EventRole,
+							cfixtures.MessageEType: message.EventRole,
+							cfixtures.MessageFType: message.EventRole,
+							cfixtures.MessageTType: message.TimeoutRole,
+						},
+					},
+				))
+			})
+		})
+
+		Describe("func TypeName()", func() {
+			It("returns the fully-qualified type name of the application", func() {
+				Expect(cfg.TypeName()).To(Equal("*github.com/dogmatiq/dogma/fixtures.Application"))
+			})
+		})
+
+		Describe("func ReflectType()", func() {
+			It("returns the type of the application", func() {
+				Expect(cfg.ReflectType()).To(Equal(reflect.TypeOf(app)))
+			})
+		})
+
+		Describe("func AcceptVisitor()", func() {
+			It("calls the appropriate method on the visitor", func() {
+				v := &cfixtures.Visitor{
+					VisitApplicationFunc: func(_ context.Context, c Application) error {
+						Expect(c).To(BeIdenticalTo(cfg))
+						return errors.New("<error>")
+					},
+				}
+
+				err := cfg.AcceptVisitor(context.Background(), v)
+				Expect(err).To(MatchError("<error>"))
+			})
+		})
+
+		Describe("func AcceptRichVisitor()", func() {
+			It("calls the appropriate method on the visitor", func() {
+				v := &cfixtures.RichVisitor{
+					VisitRichApplicationFunc: func(_ context.Context, c RichApplication) error {
+						Expect(c).To(BeIdenticalTo(cfg))
+						return errors.New("<error>")
+					},
+				}
+
+				err := cfg.AcceptRichVisitor(context.Background(), v)
+				Expect(err).To(MatchError("<error>"))
+			})
+		})
+
+		XDescribe("func Handlers()", func() {
+			It("returns a set containing all handlers in the application", func() {
+				Expect(cfg.Handlers()).To(Equal(
+					NewHandlerSet(
+						FromAggregate(aggregate),
+						FromProcess(process),
+						FromIntegration(integration),
+						FromProjection(projection),
+					),
+				))
+			})
+		})
+
+		XDescribe("func RichHandlers()", func() {
+			It("returns a set containing all handlers in the application", func() {
+				Expect(cfg.Handlers()).To(Equal(
+					NewRichHandlerSet(
+						FromAggregate(aggregate),
+						FromProcess(process),
+						FromIntegration(integration),
+						FromProjection(projection),
+					),
+				))
+			})
+		})
+
+		XDescribe("func ForeignMessageNames()", func() {
+			It("returns the set of messages that belong to another application", func() {
+				Expect(cfg.ForeignMessageNames()).To(Equal(
+					message.NameRoles{
+						cfixtures.MessageXTypeName: message.CommandRole,
+						cfixtures.MessageYTypeName: message.EventRole,
+					},
+				))
+			})
+		})
+
+		XDescribe("func ForeignMessageTypes()", func() {
+			It("returns the set of messages that belong to another application", func() {
+				Expect(cfg.ForeignMessageTypes()).To(Equal(
+					message.TypeRoles{
+						cfixtures.MessageXType: message.CommandRole,
+						cfixtures.MessageYType: message.EventRole,
+					},
+				))
+			})
+		})
+
+		Describe("func Application()", func() {
+			It("returns the underlying application", func() {
+				Expect(cfg.Application()).To(BeIdenticalTo(app))
+			})
+		})
+	})
+
+	DescribeTable(
+		"when the configuration is invalid",
+		func(
+			msg string,
+			fn func(),
+		) {
+			fn()
+
+			var err error
+			func() {
+				defer Recover(&err)
+				FromApplication(app)
+			}()
+
+			Expect(err).Should(HaveOccurred())
+			if msg != "" {
+				Expect(err).To(MatchError(msg))
+			}
+		},
+		// 	When("the app does not configure an identity", func() {
+		// 		BeforeEach(func() {
+		// 			app.ConfigureFunc = nil
+		// 		})
+
+		// 		It("returns a descriptive error", func() {
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					"*fixtures.Application.Configure() did not call ApplicationConfigurer.Identity()",
+		// 				),
+		// 			))
+		// 		})
+		// 	})
+
+		// 	When("the app configures multiple identities", func() {
+		// 		BeforeEach(func() {
+		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+		// 				c.Identity("<name>", "<key>")
+		// 				c.Identity("<other>", "<key>")
+		// 			}
+		// 		})
+
+		// 		It("returns a descriptive error", func() {
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.Application.Configure() has already called ApplicationConfigurer.Identity("<name>", "<key>")`,
+		// 				),
+		// 			))
+		// 		})
+		// 	})
+
+		// 	When("the app configures an invalid application name", func() {
+		// 		BeforeEach(func() {
+		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+		// 				c.Identity("\t \n", "<app-key>")
+		// 			}
+		// 		})
+
+		// 		It("returns a descriptive error", func() {
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.Application.Configure() called ApplicationConfigurer.Identity() with an invalid name "\t \n", names must be non-empty, printable UTF-8 strings with no whitespace`,
+		// 				),
+		// 			))
+		// 		})
+		// 	})
+
+		// 	When("the app configures an invalid application key", func() {
+		// 		BeforeEach(func() {
+		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+		// 				c.Identity("<app>", "\t \n")
+		// 			}
+		// 		})
+
+		// 		It("returns a descriptive error", func() {
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.Application.Configure() called ApplicationConfigurer.Identity() with an invalid key "\t \n", keys must be non-empty, printable UTF-8 strings with no whitespace`,
+		// 				),
+		// 			))
+		// 		})
+		// 	})
+
+		// 	When("the app contains an invalid handler configurations", func() {
+		// 		It("returns an error when an aggregate is misconfigured", func() {
+		// 			aggregate.ConfigureFunc = nil
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).Should(HaveOccurred())
+		// 		})
+
+		// 		It("returns an error when a process is misconfigured", func() {
+		// 			process.ConfigureFunc = nil
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).Should(HaveOccurred())
+		// 		})
+
+		// 		It("returns an error when an integration is misconfigured", func() {
+		// 			integration.ConfigureFunc = nil
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).Should(HaveOccurred())
+		// 		})
+
+		// 		It("returns an error when a projection is misconfigured", func() {
+		// 			projection.ConfigureFunc = nil
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).Should(HaveOccurred())
+		// 		})
+		// 	})
+
+		// 	When("the app contains conflicting handler identities", func() {
+		// 		It("returns an error when an aggregate name is in conflict", func() {
+		// 			aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+		// 				c.Identity("<process>", "<aggregate-key>") // conflict!
+		// 				c.ConsumesCommandType(fixtures.MessageA{})
+		// 				c.ProducesEventType(fixtures.MessageE{})
+		// 			}
+
+		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+		// 				c.Identity("<app>", "<app-key>")
+		// 				c.RegisterProcess(process)
+		// 				c.RegisterAggregate(aggregate) // register the conflicting aggregate last
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.AggregateMessageHandler can not use the handler name "<process>", because it is already used by *fixtures.ProcessMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when an aggregate key is in conflict", func() {
+		// 			aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+		// 				c.Identity("<aggregate>", "<process-key>") // conflict!
+		// 				c.ConsumesCommandType(fixtures.MessageA{})
+		// 				c.ProducesEventType(fixtures.MessageE{})
+		// 			}
+
+		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+		// 				c.Identity("<app>", "<app-key>")
+		// 				c.RegisterProcess(process)
+		// 				c.RegisterAggregate(aggregate) // register the conflicting aggregate last
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.AggregateMessageHandler can not use the handler key "<process-key>", because it is already used by *fixtures.ProcessMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when a process name is in conflict", func() {
+		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
+		// 				c.Identity("<aggregate>", "<process-key>") // conflict!
+		// 				c.ConsumesEventType(fixtures.MessageB{})
+		// 				c.ProducesCommandType(fixtures.MessageC{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.ProcessMessageHandler can not use the handler name "<aggregate>", because it is already used by *fixtures.AggregateMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when a process key is in conflict", func() {
+		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
+		// 				c.Identity("<process>", "<aggregate-key>") // conflict!
+		// 				c.ConsumesEventType(fixtures.MessageB{})
+		// 				c.ProducesCommandType(fixtures.MessageC{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.ProcessMessageHandler can not use the handler key "<aggregate-key>", because it is already used by *fixtures.AggregateMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when an integration name is in conflict", func() {
+		// 			integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+		// 				c.Identity("<process>", "<integration-key>") // conflict!
+		// 				c.ConsumesCommandType(fixtures.MessageC{})
+		// 				c.ProducesEventType(fixtures.MessageF{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.IntegrationMessageHandler can not use the handler name "<process>", because it is already used by *fixtures.ProcessMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when an integration key is in conflict", func() {
+		// 			integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+		// 				c.Identity("<integration>", "<process-key>") // conflict!
+		// 				c.ConsumesCommandType(fixtures.MessageC{})
+		// 				c.ProducesEventType(fixtures.MessageF{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.IntegrationMessageHandler can not use the handler key "<process-key>", because it is already used by *fixtures.ProcessMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when a projection name is in conflict", func() {
+		// 			projection.ConfigureFunc = func(c dogma.ProjectionConfigurer) {
+		// 				c.Identity("<integration>", "<projection-key>") // conflict!
+		// 				c.ConsumesEventType(fixtures.MessageD{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.ProjectionMessageHandler can not use the handler name "<integration>", because it is already used by *fixtures.IntegrationMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when a projection key is in conflict", func() {
+		// 			projection.ConfigureFunc = func(c dogma.ProjectionConfigurer) {
+		// 				c.Identity("<projection>", "<integration-key>") // conflict!
+		// 				c.ConsumesEventType(fixtures.MessageD{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`*fixtures.ProjectionMessageHandler can not use the handler key "<integration-key>", because it is already used by *fixtures.IntegrationMessageHandler`,
+		// 				),
+		// 			))
+		// 		})
+		// 	})
+
+		// 	It("returns an error when the app contains multiple consumers of the same command", func() {
+		// 		integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+		// 			c.Identity("<integration>", "<integration-key>")
+		// 			c.ConsumesCommandType(fixtures.MessageA{}) // conflict with <aggregate>
+		// 			c.ProducesEventType(fixtures.MessageF{})
+		// 		}
+
+		// 		_, err := FromApplication(app)
+
+		// 		Expect(err).To(Equal(
+		// 			Error(
+		// 				`the "<integration>" handler can not consume fixtures.MessageA commands because they are already consumed by "<aggregate>"`,
+		// 			),
+		// 		))
+		// 	})
+
+		// 	It("returns an error when the app contains multiple producers of the same event", func() {
+		// 		integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+		// 			c.Identity("<integration>", "<integration-key>")
+		// 			c.ConsumesCommandType(fixtures.MessageC{})
+		// 			c.ProducesEventType(fixtures.MessageE{}) // conflict with <aggregate>
+		// 		}
+
+		// 		_, err := FromApplication(app)
+
+		// 		Expect(err).To(Equal(
+		// 			Error(
+		// 				`the "<integration>" handler can not produce fixtures.MessageE events because they are already produced by "<aggregate>"`,
+		// 			),
+		// 		))
+		// 	})
+
+		// 	It("does not return an error when the app contains multiple processes that schedule the same timeout", func() {
+		// 		process1 := &fixtures.ProcessMessageHandler{
+		// 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+		// 				c.Identity("<process-1>", "<process-1-key>")
+		// 				c.ConsumesEventType(fixtures.MessageB{})
+		// 				c.ProducesCommandType(fixtures.MessageC{})
+		// 				c.SchedulesTimeoutType(fixtures.MessageT{})
+		// 			},
+		// 		}
+
+		// 		process2 := &fixtures.ProcessMessageHandler{
+		// 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
+		// 				c.Identity("<process-2>", "<process-2-key>")
+		// 				c.ConsumesEventType(fixtures.MessageB{})
+		// 				c.ProducesCommandType(fixtures.MessageC{})
+		// 				c.SchedulesTimeoutType(fixtures.MessageT{})
+		// 			},
+		// 		}
+
+		// 		app := &fixtures.Application{
+		// 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+		// 				c.Identity("<app>", "<app-key>")
+		// 				c.RegisterProcess(process1)
+		// 				c.RegisterProcess(process2)
+		// 			},
+		// 		}
+
+		// 		_, err := FromApplication(app)
+
+		// 		Expect(err).ShouldNot(HaveOccurred())
+		// 	})
+
+		// 	When("multiple handlers use a single message type in differing roles", func() {
+		// 		It("returns an error when a conflict occurs with a consumed message", func() {
+		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
+		// 				c.Identity("<process>", "<process-key>")
+		// 				c.ConsumesEventType(fixtures.MessageA{}) // conflict with <aggregate>
+		// 				c.ProducesCommandType(fixtures.MessageC{})
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`the "<process>" handler configures fixtures.MessageA as an event but "<aggregate>" configures it as a command`,
+		// 				),
+		// 			))
+		// 		})
+
+		// 		It("returns an error when a conflict occurs with a produced message", func() {
+		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
+		// 				c.Identity("<process>", "<process-key>")
+		// 				c.ConsumesEventType(fixtures.MessageB{})
+		// 				c.ProducesCommandType(fixtures.MessageE{}) // conflict with <aggregate>
+		// 			}
+
+		// 			_, err := FromApplication(app)
+
+		// 			Expect(err).To(Equal(
+		// 				Error(
+		// 					`the "<process>" handler configures fixtures.MessageE as a command but "<aggregate>" configures it as an event`,
+		// 				),
+		// 			))
+		// 		})
+		// 	})
+	)
+})

--- a/application_test.go
+++ b/application_test.go
@@ -250,6 +250,18 @@ var _ = Describe("func FromApplication()", func() {
 			})
 		})
 
+		It("does not panic when the app name is shared with handler", func() {
+			aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+				c.Identity("<app>", "<aggregate-key>")
+				c.ConsumesCommandType(fixtures.MessageA{})
+				c.ProducesEventType(fixtures.MessageE{})
+			}
+
+			Expect(func() {
+				FromApplication(app)
+			}).NotTo(Panic())
+		})
+
 		It("does not panic when the app contains multiple processes that schedule the same timeout", func() {
 			process1 := &fixtures.ProcessMessageHandler{
 				ConfigureFunc: func(c dogma.ProcessConfigurer) {
@@ -277,7 +289,9 @@ var _ = Describe("func FromApplication()", func() {
 				},
 			}
 
-			FromApplication(app)
+			Expect(func() {
+				FromApplication(app)
+			}).NotTo(Panic())
 		})
 	})
 

--- a/application_test.go
+++ b/application_test.go
@@ -36,9 +36,10 @@ var _ = Describe("func FromApplication()", func() {
 		process = &fixtures.ProcessMessageHandler{
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<process>", "<process-key>")
-				c.ConsumesEventType(fixtures.MessageB{})
+				c.ConsumesEventType(fixtures.MessageB{}) // foreign event
 				c.ConsumesEventType(fixtures.MessageE{}) // shared with <projection>
 				c.ProducesCommandType(fixtures.MessageC{})
+				c.ProducesCommandType(fixtures.MessageX{}) // foreign command
 				c.SchedulesTimeoutType(fixtures.MessageT{})
 			},
 		}
@@ -54,7 +55,7 @@ var _ = Describe("func FromApplication()", func() {
 		projection = &fixtures.ProjectionMessageHandler{
 			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
 				c.Identity("<projection>", "<projection-key>")
-				c.ConsumesEventType(fixtures.MessageD{})
+				c.ConsumesEventType(fixtures.MessageD{}) // foreign
 				c.ConsumesEventType(fixtures.MessageE{}) // shared with <process>
 			},
 		}
@@ -85,7 +86,7 @@ var _ = Describe("func FromApplication()", func() {
 			})
 		})
 
-		XDescribe("func MessageNames()", func() {
+		Describe("func MessageNames()", func() {
 			It("returns the expected message names", func() {
 				Expect(cfg.MessageNames()).To(Equal(
 					EntityMessageNames{
@@ -97,15 +98,14 @@ var _ = Describe("func FromApplication()", func() {
 							cfixtures.MessageETypeName: message.EventRole,
 							cfixtures.MessageFTypeName: message.EventRole,
 							cfixtures.MessageTTypeName: message.TimeoutRole,
+							cfixtures.MessageXTypeName: message.CommandRole,
 						},
 						Produced: message.NameRoles{
-							cfixtures.MessageATypeName: message.CommandRole,
-							cfixtures.MessageBTypeName: message.EventRole,
 							cfixtures.MessageCTypeName: message.CommandRole,
-							cfixtures.MessageDTypeName: message.EventRole,
 							cfixtures.MessageETypeName: message.EventRole,
 							cfixtures.MessageFTypeName: message.EventRole,
 							cfixtures.MessageTTypeName: message.TimeoutRole,
+							cfixtures.MessageXTypeName: message.CommandRole,
 						},
 						Consumed: message.NameRoles{
 							cfixtures.MessageATypeName: message.CommandRole,
@@ -113,7 +113,6 @@ var _ = Describe("func FromApplication()", func() {
 							cfixtures.MessageCTypeName: message.CommandRole,
 							cfixtures.MessageDTypeName: message.EventRole,
 							cfixtures.MessageETypeName: message.EventRole,
-							cfixtures.MessageFTypeName: message.EventRole,
 							cfixtures.MessageTTypeName: message.TimeoutRole,
 						},
 					},
@@ -121,7 +120,7 @@ var _ = Describe("func FromApplication()", func() {
 			})
 		})
 
-		XDescribe("func MessageTypes()", func() {
+		Describe("func MessageTypes()", func() {
 			It("returns the expected message types", func() {
 				Expect(cfg.MessageTypes()).To(Equal(
 					EntityMessageTypes{
@@ -133,15 +132,14 @@ var _ = Describe("func FromApplication()", func() {
 							cfixtures.MessageEType: message.EventRole,
 							cfixtures.MessageFType: message.EventRole,
 							cfixtures.MessageTType: message.TimeoutRole,
+							cfixtures.MessageXType: message.CommandRole,
 						},
 						Produced: message.TypeRoles{
-							cfixtures.MessageAType: message.CommandRole,
-							cfixtures.MessageBType: message.EventRole,
 							cfixtures.MessageCType: message.CommandRole,
-							cfixtures.MessageDType: message.EventRole,
 							cfixtures.MessageEType: message.EventRole,
 							cfixtures.MessageFType: message.EventRole,
 							cfixtures.MessageTType: message.TimeoutRole,
+							cfixtures.MessageXType: message.CommandRole,
 						},
 						Consumed: message.TypeRoles{
 							cfixtures.MessageAType: message.CommandRole,
@@ -149,7 +147,6 @@ var _ = Describe("func FromApplication()", func() {
 							cfixtures.MessageCType: message.CommandRole,
 							cfixtures.MessageDType: message.EventRole,
 							cfixtures.MessageEType: message.EventRole,
-							cfixtures.MessageFType: message.EventRole,
 							cfixtures.MessageTType: message.TimeoutRole,
 						},
 					},
@@ -210,9 +207,9 @@ var _ = Describe("func FromApplication()", func() {
 			})
 		})
 
-		XDescribe("func RichHandlers()", func() {
+		Describe("func RichHandlers()", func() {
 			It("returns a set containing all handlers in the application", func() {
-				Expect(cfg.Handlers()).To(Equal(
+				Expect(cfg.RichHandlers()).To(Equal(
 					NewRichHandlerSet(
 						FromAggregate(aggregate),
 						FromProcess(process),
@@ -223,23 +220,25 @@ var _ = Describe("func FromApplication()", func() {
 			})
 		})
 
-		XDescribe("func ForeignMessageNames()", func() {
+		Describe("func ForeignMessageNames()", func() {
 			It("returns the set of messages that belong to another application", func() {
 				Expect(cfg.ForeignMessageNames()).To(Equal(
 					message.NameRoles{
+						cfixtures.MessageBTypeName: message.EventRole,
+						cfixtures.MessageDTypeName: message.EventRole,
 						cfixtures.MessageXTypeName: message.CommandRole,
-						cfixtures.MessageYTypeName: message.EventRole,
 					},
 				))
 			})
 		})
 
-		XDescribe("func ForeignMessageTypes()", func() {
+		Describe("func ForeignMessageTypes()", func() {
 			It("returns the set of messages that belong to another application", func() {
 				Expect(cfg.ForeignMessageTypes()).To(Equal(
 					message.TypeRoles{
+						cfixtures.MessageBType: message.EventRole,
+						cfixtures.MessageDType: message.EventRole,
 						cfixtures.MessageXType: message.CommandRole,
-						cfixtures.MessageYType: message.EventRole,
 					},
 				))
 			})

--- a/application_test.go
+++ b/application_test.go
@@ -249,6 +249,36 @@ var _ = Describe("func FromApplication()", func() {
 				Expect(cfg.Application()).To(BeIdenticalTo(app))
 			})
 		})
+
+		It("does not panic when the app contains multiple processes that schedule the same timeout", func() {
+			process1 := &fixtures.ProcessMessageHandler{
+				ConfigureFunc: func(c dogma.ProcessConfigurer) {
+					c.Identity("<process-1>", "<process-1-key>")
+					c.ConsumesEventType(fixtures.MessageB{})
+					c.ProducesCommandType(fixtures.MessageC{})
+					c.SchedulesTimeoutType(fixtures.MessageT{})
+				},
+			}
+
+			process2 := &fixtures.ProcessMessageHandler{
+				ConfigureFunc: func(c dogma.ProcessConfigurer) {
+					c.Identity("<process-2>", "<process-2-key>")
+					c.ConsumesEventType(fixtures.MessageB{})
+					c.ProducesCommandType(fixtures.MessageC{})
+					c.SchedulesTimeoutType(fixtures.MessageT{})
+				},
+			}
+
+			app := &fixtures.Application{
+				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+					c.Identity("<app>", "<app-key>")
+					c.RegisterProcess(process1)
+					c.RegisterProcess(process2)
+				},
+			}
+
+			FromApplication(app)
+		})
 	})
 
 	DescribeTable(

--- a/application_test.go
+++ b/application_test.go
@@ -314,347 +314,173 @@ var _ = Describe("func FromApplication()", func() {
 				Expect(err).To(MatchError(msg))
 			}
 		},
-		// 	When("the app does not configure an identity", func() {
-		// 		BeforeEach(func() {
-		// 			app.ConfigureFunc = nil
-		// 		})
-
-		// 		It("returns a descriptive error", func() {
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					"*fixtures.Application.Configure() did not call ApplicationConfigurer.Identity()",
-		// 				),
-		// 			))
-		// 		})
-		// 	})
-
-		// 	When("the app configures multiple identities", func() {
-		// 		BeforeEach(func() {
-		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
-		// 				c.Identity("<name>", "<key>")
-		// 				c.Identity("<other>", "<key>")
-		// 			}
-		// 		})
-
-		// 		It("returns a descriptive error", func() {
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.Application.Configure() has already called ApplicationConfigurer.Identity("<name>", "<key>")`,
-		// 				),
-		// 			))
-		// 		})
-		// 	})
-
-		// 	When("the app configures an invalid application name", func() {
-		// 		BeforeEach(func() {
-		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
-		// 				c.Identity("\t \n", "<app-key>")
-		// 			}
-		// 		})
-
-		// 		It("returns a descriptive error", func() {
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.Application.Configure() called ApplicationConfigurer.Identity() with an invalid name "\t \n", names must be non-empty, printable UTF-8 strings with no whitespace`,
-		// 				),
-		// 			))
-		// 		})
-		// 	})
-
-		// 	When("the app configures an invalid application key", func() {
-		// 		BeforeEach(func() {
-		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
-		// 				c.Identity("<app>", "\t \n")
-		// 			}
-		// 		})
-
-		// 		It("returns a descriptive error", func() {
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.Application.Configure() called ApplicationConfigurer.Identity() with an invalid key "\t \n", keys must be non-empty, printable UTF-8 strings with no whitespace`,
-		// 				),
-		// 			))
-		// 		})
-		// 	})
-
-		// 	When("the app contains an invalid handler configurations", func() {
-		// 		It("returns an error when an aggregate is misconfigured", func() {
-		// 			aggregate.ConfigureFunc = nil
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).Should(HaveOccurred())
-		// 		})
-
-		// 		It("returns an error when a process is misconfigured", func() {
-		// 			process.ConfigureFunc = nil
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).Should(HaveOccurred())
-		// 		})
-
-		// 		It("returns an error when an integration is misconfigured", func() {
-		// 			integration.ConfigureFunc = nil
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).Should(HaveOccurred())
-		// 		})
-
-		// 		It("returns an error when a projection is misconfigured", func() {
-		// 			projection.ConfigureFunc = nil
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).Should(HaveOccurred())
-		// 		})
-		// 	})
-
-		// 	When("the app contains conflicting handler identities", func() {
-		// 		It("returns an error when an aggregate name is in conflict", func() {
-		// 			aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
-		// 				c.Identity("<process>", "<aggregate-key>") // conflict!
-		// 				c.ConsumesCommandType(fixtures.MessageA{})
-		// 				c.ProducesEventType(fixtures.MessageE{})
-		// 			}
-
-		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
-		// 				c.Identity("<app>", "<app-key>")
-		// 				c.RegisterProcess(process)
-		// 				c.RegisterAggregate(aggregate) // register the conflicting aggregate last
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.AggregateMessageHandler can not use the handler name "<process>", because it is already used by *fixtures.ProcessMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when an aggregate key is in conflict", func() {
-		// 			aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
-		// 				c.Identity("<aggregate>", "<process-key>") // conflict!
-		// 				c.ConsumesCommandType(fixtures.MessageA{})
-		// 				c.ProducesEventType(fixtures.MessageE{})
-		// 			}
-
-		// 			app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
-		// 				c.Identity("<app>", "<app-key>")
-		// 				c.RegisterProcess(process)
-		// 				c.RegisterAggregate(aggregate) // register the conflicting aggregate last
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.AggregateMessageHandler can not use the handler key "<process-key>", because it is already used by *fixtures.ProcessMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when a process name is in conflict", func() {
-		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
-		// 				c.Identity("<aggregate>", "<process-key>") // conflict!
-		// 				c.ConsumesEventType(fixtures.MessageB{})
-		// 				c.ProducesCommandType(fixtures.MessageC{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.ProcessMessageHandler can not use the handler name "<aggregate>", because it is already used by *fixtures.AggregateMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when a process key is in conflict", func() {
-		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
-		// 				c.Identity("<process>", "<aggregate-key>") // conflict!
-		// 				c.ConsumesEventType(fixtures.MessageB{})
-		// 				c.ProducesCommandType(fixtures.MessageC{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.ProcessMessageHandler can not use the handler key "<aggregate-key>", because it is already used by *fixtures.AggregateMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when an integration name is in conflict", func() {
-		// 			integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
-		// 				c.Identity("<process>", "<integration-key>") // conflict!
-		// 				c.ConsumesCommandType(fixtures.MessageC{})
-		// 				c.ProducesEventType(fixtures.MessageF{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.IntegrationMessageHandler can not use the handler name "<process>", because it is already used by *fixtures.ProcessMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when an integration key is in conflict", func() {
-		// 			integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
-		// 				c.Identity("<integration>", "<process-key>") // conflict!
-		// 				c.ConsumesCommandType(fixtures.MessageC{})
-		// 				c.ProducesEventType(fixtures.MessageF{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.IntegrationMessageHandler can not use the handler key "<process-key>", because it is already used by *fixtures.ProcessMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when a projection name is in conflict", func() {
-		// 			projection.ConfigureFunc = func(c dogma.ProjectionConfigurer) {
-		// 				c.Identity("<integration>", "<projection-key>") // conflict!
-		// 				c.ConsumesEventType(fixtures.MessageD{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.ProjectionMessageHandler can not use the handler name "<integration>", because it is already used by *fixtures.IntegrationMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when a projection key is in conflict", func() {
-		// 			projection.ConfigureFunc = func(c dogma.ProjectionConfigurer) {
-		// 				c.Identity("<projection>", "<integration-key>") // conflict!
-		// 				c.ConsumesEventType(fixtures.MessageD{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`*fixtures.ProjectionMessageHandler can not use the handler key "<integration-key>", because it is already used by *fixtures.IntegrationMessageHandler`,
-		// 				),
-		// 			))
-		// 		})
-		// 	})
-
-		// 	It("returns an error when the app contains multiple consumers of the same command", func() {
-		// 		integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
-		// 			c.Identity("<integration>", "<integration-key>")
-		// 			c.ConsumesCommandType(fixtures.MessageA{}) // conflict with <aggregate>
-		// 			c.ProducesEventType(fixtures.MessageF{})
-		// 		}
-
-		// 		_, err := FromApplication(app)
-
-		// 		Expect(err).To(Equal(
-		// 			Error(
-		// 				`the "<integration>" handler can not consume fixtures.MessageA commands because they are already consumed by "<aggregate>"`,
-		// 			),
-		// 		))
-		// 	})
-
-		// 	It("returns an error when the app contains multiple producers of the same event", func() {
-		// 		integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
-		// 			c.Identity("<integration>", "<integration-key>")
-		// 			c.ConsumesCommandType(fixtures.MessageC{})
-		// 			c.ProducesEventType(fixtures.MessageE{}) // conflict with <aggregate>
-		// 		}
-
-		// 		_, err := FromApplication(app)
-
-		// 		Expect(err).To(Equal(
-		// 			Error(
-		// 				`the "<integration>" handler can not produce fixtures.MessageE events because they are already produced by "<aggregate>"`,
-		// 			),
-		// 		))
-		// 	})
-
-		// 	It("does not return an error when the app contains multiple processes that schedule the same timeout", func() {
-		// 		process1 := &fixtures.ProcessMessageHandler{
-		// 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
-		// 				c.Identity("<process-1>", "<process-1-key>")
-		// 				c.ConsumesEventType(fixtures.MessageB{})
-		// 				c.ProducesCommandType(fixtures.MessageC{})
-		// 				c.SchedulesTimeoutType(fixtures.MessageT{})
-		// 			},
-		// 		}
-
-		// 		process2 := &fixtures.ProcessMessageHandler{
-		// 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
-		// 				c.Identity("<process-2>", "<process-2-key>")
-		// 				c.ConsumesEventType(fixtures.MessageB{})
-		// 				c.ProducesCommandType(fixtures.MessageC{})
-		// 				c.SchedulesTimeoutType(fixtures.MessageT{})
-		// 			},
-		// 		}
-
-		// 		app := &fixtures.Application{
-		// 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
-		// 				c.Identity("<app>", "<app-key>")
-		// 				c.RegisterProcess(process1)
-		// 				c.RegisterProcess(process2)
-		// 			},
-		// 		}
-
-		// 		_, err := FromApplication(app)
-
-		// 		Expect(err).ShouldNot(HaveOccurred())
-		// 	})
-
-		// 	When("multiple handlers use a single message type in differing roles", func() {
-		// 		It("returns an error when a conflict occurs with a consumed message", func() {
-		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
-		// 				c.Identity("<process>", "<process-key>")
-		// 				c.ConsumesEventType(fixtures.MessageA{}) // conflict with <aggregate>
-		// 				c.ProducesCommandType(fixtures.MessageC{})
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`the "<process>" handler configures fixtures.MessageA as an event but "<aggregate>" configures it as a command`,
-		// 				),
-		// 			))
-		// 		})
-
-		// 		It("returns an error when a conflict occurs with a produced message", func() {
-		// 			process.ConfigureFunc = func(c dogma.ProcessConfigurer) {
-		// 				c.Identity("<process>", "<process-key>")
-		// 				c.ConsumesEventType(fixtures.MessageB{})
-		// 				c.ProducesCommandType(fixtures.MessageE{}) // conflict with <aggregate>
-		// 			}
-
-		// 			_, err := FromApplication(app)
-
-		// 			Expect(err).To(Equal(
-		// 				Error(
-		// 					`the "<process>" handler configures fixtures.MessageE as a command but "<aggregate>" configures it as an event`,
-		// 				),
-		// 			))
-		// 		})
-		// 	})
+		Entry(
+			"when the app does not configure anything",
+			"", // any error
+			func() {
+				app.ConfigureFunc = nil
+			},
+		),
+		Entry(
+			"when the app does not configure an identity",
+			`*fixtures.Application is configured without an identity, Identity() must be called exactly once within Configure()`,
+			func() {
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.RegisterAggregate(aggregate)
+				}
+			},
+		),
+		Entry(
+			"when the app configures multiple identities",
+			`*fixtures.Application is configured with multiple identities (<name>/<key> and <other>/<key>), Identity() must be called exactly once within Configure()`,
+			func() {
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.Identity("<name>", "<key>")
+					c.Identity("<other>", "<key>")
+					c.RegisterAggregate(aggregate)
+				}
+			},
+		),
+		Entry(
+			"when the app configures an invalid name",
+			`*fixtures.Application is configured with an invalid identity, invalid name "\t \n", names must be non-empty, printable UTF-8 strings with no whitespace`,
+			func() {
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.Identity("\t \n", "<key>")
+					c.RegisterAggregate(aggregate)
+				}
+			},
+		),
+		Entry(
+			"when the app configures an invalid key",
+			`*fixtures.Application is configured with an invalid identity, invalid key "\t \n", keys must be non-empty, printable UTF-8 strings with no whitespace`,
+			func() {
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.Identity("<name>", "\t \n")
+					c.RegisterAggregate(aggregate)
+				}
+			},
+		),
+		Entry(
+			"when the app configures an identity that conflicts with a handler",
+			`*fixtures.Application can not use the application key "<aggregate-key>", because it is already used by *fixtures.AggregateMessageHandler`,
+			func() {
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.RegisterAggregate(aggregate)
+					c.Identity("<app>", "<aggregate-key>") // conflict
+				}
+			},
+		),
+		Entry(
+			"when a handler is registered with a key that conflicts with the app",
+			`*fixtures.AggregateMessageHandler can not use the handler key "<app-key>", because it is already used by *fixtures.Application`,
+			func() {
+				aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+					c.Identity("<aggregate>", "<app-key>") // conflict!
+					c.ConsumesCommandType(fixtures.MessageA{})
+					c.ProducesEventType(fixtures.MessageE{})
+				}
+			},
+		),
+		Entry(
+			"when the app contains an invalid aggregate configuration",
+			"", // any error
+			func() {
+				aggregate.ConfigureFunc = nil
+			},
+		),
+		Entry(
+			"when the app contains an invalid process configuration",
+			"", // any error
+			func() {
+				process.ConfigureFunc = nil
+			},
+		),
+		Entry(
+			"when the app contains an invalid integration configuration",
+			"", // any error
+			func() {
+				integration.ConfigureFunc = nil
+			},
+		),
+		Entry(
+			"when the app contains an invalid projection configuration",
+			"", // any error
+			func() {
+				projection.ConfigureFunc = nil
+			},
+		),
+		Entry(
+			"the app contains handlers with conflicting names",
+			`*fixtures.AggregateMessageHandler can not use the handler name "<process>", because it is already used by *fixtures.ProcessMessageHandler`,
+			func() {
+				aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+					c.Identity("<process>", "<aggregate-key>") // conflict!
+					c.ConsumesCommandType(fixtures.MessageA{})
+					c.ProducesEventType(fixtures.MessageE{})
+				}
+
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.Identity("<app>", "<app-key>")
+					c.RegisterProcess(process)
+					c.RegisterAggregate(aggregate) // register the conflicting aggregate last
+				}
+			},
+		),
+		Entry(
+			"the app contains handlers with conflicting keys",
+			`*fixtures.AggregateMessageHandler can not use the handler key "<process-key>", because it is already used by *fixtures.ProcessMessageHandler`,
+			func() {
+				aggregate.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+					c.Identity("<aggregate>", "<process-key>") // conflict!
+					c.ConsumesCommandType(fixtures.MessageA{})
+					c.ProducesEventType(fixtures.MessageE{})
+				}
+
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.Identity("<app>", "<app-key>")
+					c.RegisterProcess(process)
+					c.RegisterAggregate(aggregate) // register the conflicting aggregate last
+				}
+			},
+		),
+		Entry(
+			"when the app contains multiple consumers of the same command",
+			`*fixtures.IntegrationMessageHandler (<integration>) can not consume fixtures.MessageA commands because they are already consumed by *fixtures.AggregateMessageHandler (<aggregate>)`,
+			func() {
+				integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+					c.Identity("<integration>", "<integration-key>")
+					c.ConsumesCommandType(fixtures.MessageA{}) // conflict with <aggregate>
+					c.ProducesEventType(fixtures.MessageF{})
+				}
+			},
+		),
+		Entry(
+			"when the app contains multiple producers of the same event",
+			`*fixtures.IntegrationMessageHandler (<integration>) can not produce fixtures.MessageE events because they are already produced by *fixtures.AggregateMessageHandler (<aggregate>)`,
+			func() {
+				integration.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+					c.Identity("<integration>", "<integration-key>")
+					c.ConsumesCommandType(fixtures.MessageC{})
+					c.ProducesEventType(fixtures.MessageE{}) // conflict with <aggregate>
+				}
+			},
+		),
+		Entry(
+			"when multiple handlers use a single message type in differing roles",
+			`*fixtures.ProjectionMessageHandler (<projection>) configures fixtures.MessageA as an event but *fixtures.AggregateMessageHandler (<aggregate>) configures it as a command`,
+			func() {
+				projection.ConfigureFunc = func(c dogma.ProjectionConfigurer) {
+					c.Identity("<projection>", "<projection-key>")
+					c.ConsumesEventType(fixtures.MessageA{}) // conflict with <aggregate>
+				}
+
+				app.ConfigureFunc = func(c dogma.ApplicationConfigurer) {
+					c.Identity("<app>", "<app-key>")
+					c.RegisterAggregate(aggregate)
+					c.RegisterProjection(projection)
+				}
+			},
+		),
 	)
 })

--- a/applicationconfigurer.go
+++ b/applicationconfigurer.go
@@ -45,6 +45,7 @@ func (c *applicationConfigurer) RegisterProjection(h dogma.ProjectionMessageHand
 	c.register(cfg)
 }
 
+// register adds a handler configuration to the application.
 func (c *applicationConfigurer) register(h RichHandler) {
 	c.guardAgainstConflictingIdentities(h)
 	c.guardAgainstConflictingRoles(h)
@@ -91,6 +92,7 @@ func (c *applicationConfigurer) register(h RichHandler) {
 	}
 }
 
+// validate panics if the configuration is invalid.
 func (c *applicationConfigurer) validate() {
 	c.entityConfigurer.validate()
 

--- a/applicationconfigurer.go
+++ b/applicationconfigurer.go
@@ -5,20 +5,36 @@ import "github.com/dogmatiq/dogma"
 // applicationConfigurer is an implementation of dogma.ApplicationConfigurer.
 type applicationConfigurer struct {
 	entityConfigurer
+
+	target *application
 }
 
 func (c *applicationConfigurer) RegisterAggregate(h dogma.AggregateMessageHandler) {
-
+	cfg := FromAggregate(h)
+	c.register(cfg)
 }
 
 func (c *applicationConfigurer) RegisterProcess(h dogma.ProcessMessageHandler) {
-
+	cfg := FromProcess(h)
+	c.register(cfg)
 }
 
 func (c *applicationConfigurer) RegisterIntegration(h dogma.IntegrationMessageHandler) {
-
+	cfg := FromIntegration(h)
+	c.register(cfg)
 }
 
 func (c *applicationConfigurer) RegisterProjection(h dogma.ProjectionMessageHandler) {
+	cfg := FromProjection(h)
+	c.register(cfg)
+}
 
+func (c *applicationConfigurer) register(h RichHandler) {
+	if c.target.handlers == nil {
+		c.target.handlers = HandlerSet{}
+		c.target.richHandlers = RichHandlerSet{}
+	}
+
+	c.target.handlers.Add(h)
+	c.target.richHandlers.Add(h)
 }

--- a/applicationconfigurer.go
+++ b/applicationconfigurer.go
@@ -1,0 +1,24 @@
+package configkit
+
+import "github.com/dogmatiq/dogma"
+
+// applicationConfigurer is an implementation of dogma.ApplicationConfigurer.
+type applicationConfigurer struct {
+	entityConfigurer
+}
+
+func (c *applicationConfigurer) RegisterAggregate(h dogma.AggregateMessageHandler) {
+
+}
+
+func (c *applicationConfigurer) RegisterProcess(h dogma.ProcessMessageHandler) {
+
+}
+
+func (c *applicationConfigurer) RegisterIntegration(h dogma.IntegrationMessageHandler) {
+
+}
+
+func (c *applicationConfigurer) RegisterProjection(h dogma.ProjectionMessageHandler) {
+
+}

--- a/entityconfigurer.go
+++ b/entityconfigurer.go
@@ -9,29 +9,29 @@ package configkit
 // - dogma.IntegrationConfigurer
 // - dogma.ProjectionConfigurer
 type entityConfigurer struct {
-	// target is the entity to populate with the configuration values.
-	target *entity
+	// entity is the target entity to populate with the configuration values.
+	entity *entity
 }
 
 // Identity sets the handler's identity.
 func (c *entityConfigurer) Identity(name string, key string) {
-	if !c.target.ident.IsZero() {
+	if !c.entity.ident.IsZero() {
 		Panicf(
 			"%s is configured with multiple identities (%s and %s/%s), Identity() must be called exactly once within Configure()",
-			c.target.rt,
-			c.target.ident,
+			c.entity.rt,
+			c.entity.ident,
 			name,
 			key,
 		)
 	}
 
 	var err error
-	c.target.ident, err = NewIdentity(name, key)
+	c.entity.ident, err = NewIdentity(name, key)
 
 	if err != nil {
 		Panicf(
 			"%s is configured with an invalid identity, %s",
-			c.target.rt,
+			c.entity.rt,
 			err,
 		)
 	}
@@ -39,10 +39,10 @@ func (c *entityConfigurer) Identity(name string, key string) {
 
 // validate panics if the configuration is invalid.
 func (c *entityConfigurer) validate() {
-	if c.target.ident.IsZero() {
+	if c.entity.ident.IsZero() {
 		Panicf(
 			"%s is configured without an identity, Identity() must be called exactly once within Configure()",
-			c.target.rt,
+			c.entity.rt,
 		)
 	}
 }

--- a/entityconfigurer.go
+++ b/entityconfigurer.go
@@ -46,3 +46,15 @@ func (c *entityConfigurer) validate() {
 		)
 	}
 }
+
+// displayName returns a human-readable string used to refer to the entity in
+// error messages.
+func (c *entityConfigurer) displayName() string {
+	s := c.entity.rt.String()
+
+	if !c.entity.ident.IsZero() {
+		s += " (" + c.entity.ident.Name + ")"
+	}
+
+	return s
+}

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -54,7 +54,7 @@ func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb strin
 	mt := message.TypeOf(m)
 	c.guardAgainstRoleMismatch(mt, r)
 
-	if c.target.types.Consumed.Has(mt) {
+	if c.entity.types.Consumed.Has(mt) {
 		Panicf(
 			"%s is configured to %s the %s %s more than once, should this refer to different message types?",
 			c.displayName(),
@@ -64,21 +64,21 @@ func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb strin
 		)
 	}
 
-	if c.target.names.Roles == nil {
-		c.target.names.Roles = message.NameRoles{}
-		c.target.types.Roles = message.TypeRoles{}
+	if c.entity.names.Roles == nil {
+		c.entity.names.Roles = message.NameRoles{}
+		c.entity.types.Roles = message.TypeRoles{}
 	}
 
-	if c.target.names.Consumed == nil {
-		c.target.names.Consumed = message.NameRoles{}
-		c.target.types.Consumed = message.TypeRoles{}
+	if c.entity.names.Consumed == nil {
+		c.entity.names.Consumed = message.NameRoles{}
+		c.entity.types.Consumed = message.TypeRoles{}
 	}
 
 	n := mt.Name()
-	c.target.names.Roles.Add(n, r)
-	c.target.names.Consumed.Add(n, r)
-	c.target.types.Roles.Add(mt, r)
-	c.target.types.Consumed.Add(mt, r)
+	c.entity.names.Roles.Add(n, r)
+	c.entity.names.Consumed.Add(n, r)
+	c.entity.types.Roles.Add(mt, r)
+	c.entity.types.Consumed.Add(mt, r)
 }
 
 // produces marks the handler as a consumer of messages of the same type as m.
@@ -86,7 +86,7 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 	mt := message.TypeOf(m)
 	c.guardAgainstRoleMismatch(mt, r)
 
-	if c.target.types.Produced.Has(mt) {
+	if c.entity.types.Produced.Has(mt) {
 		Panicf(
 			"%s is configured to %s the %s %s more than once, should this refer to different message types?",
 			c.displayName(),
@@ -95,26 +95,26 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 			r,
 		)
 	}
-	if c.target.names.Roles == nil {
-		c.target.names.Roles = message.NameRoles{}
-		c.target.types.Roles = message.TypeRoles{}
+	if c.entity.names.Roles == nil {
+		c.entity.names.Roles = message.NameRoles{}
+		c.entity.types.Roles = message.TypeRoles{}
 	}
 
-	if c.target.names.Produced == nil {
-		c.target.names.Produced = message.NameRoles{}
-		c.target.types.Produced = message.TypeRoles{}
+	if c.entity.names.Produced == nil {
+		c.entity.names.Produced = message.NameRoles{}
+		c.entity.types.Produced = message.TypeRoles{}
 	}
 
 	n := mt.Name()
-	c.target.names.Roles.Add(n, r)
-	c.target.names.Produced.Add(n, r)
-	c.target.types.Roles.Add(mt, r)
-	c.target.types.Produced.Add(mt, r)
+	c.entity.names.Roles.Add(n, r)
+	c.entity.names.Produced.Add(n, r)
+	c.entity.types.Roles.Add(mt, r)
+	c.entity.types.Produced.Add(mt, r)
 }
 
 // guardAgainstRoleMismatch panics if mt is already used in some role other than r.
 func (c *handlerConfigurer) guardAgainstRoleMismatch(mt message.Type, r message.Role) {
-	x, ok := c.target.types.Roles[mt]
+	x, ok := c.entity.types.Roles[mt]
 
 	if !ok || x == r {
 		return
@@ -131,16 +131,16 @@ func (c *handlerConfigurer) guardAgainstRoleMismatch(mt message.Type, r message.
 
 // mustConsume panics if the handler does not consume any messages of the given role.
 func (c *handlerConfigurer) mustConsume(r message.Role) {
-	for mt := range c.target.names.Consumed {
-		if r == c.target.names.Roles[mt] {
+	for mt := range c.entity.names.Consumed {
+		if r == c.entity.names.Roles[mt] {
 			return
 		}
 	}
 
 	Panicf(
 		`%s (%s) is not configured to consume any %ss, Consumes%sType() must be called at least once within Configure()`,
-		c.target.rt,
-		c.target.ident.Name,
+		c.entity.rt,
+		c.entity.ident.Name,
 		r,
 		strings.Title(r.String()),
 	)
@@ -148,8 +148,8 @@ func (c *handlerConfigurer) mustConsume(r message.Role) {
 
 // mustProduce panics if the handler does not produce any messages of the given role.
 func (c *handlerConfigurer) mustProduce(r message.Role) {
-	for mt := range c.target.names.Produced {
-		if r == c.target.names.Roles[mt] {
+	for mt := range c.entity.names.Produced {
+		if r == c.entity.names.Roles[mt] {
 			return
 		}
 	}
@@ -163,10 +163,10 @@ func (c *handlerConfigurer) mustProduce(r message.Role) {
 }
 
 func (c *handlerConfigurer) displayName() string {
-	s := c.target.rt.String()
+	s := c.entity.rt.String()
 
-	if !c.target.ident.IsZero() {
-		s += " (" + c.target.ident.Name + ")"
+	if !c.entity.ident.IsZero() {
+		s += " (" + c.entity.ident.Name + ")"
 	}
 
 	return s

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -52,7 +52,7 @@ func (c *handlerConfigurer) SchedulesTimeoutType(m dogma.Message) {
 // consumes marks the handler as a consumer of messages of the same type as m.
 func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb string) {
 	mt := message.TypeOf(m)
-	c.guardAgainstRoleMismatch(mt, r)
+	c.guardAgainstConflictingRoles(mt, r)
 
 	if c.entity.types.Consumed.Has(mt) {
 		Panicf(
@@ -84,7 +84,7 @@ func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb strin
 // produces marks the handler as a consumer of messages of the same type as m.
 func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb string) {
 	mt := message.TypeOf(m)
-	c.guardAgainstRoleMismatch(mt, r)
+	c.guardAgainstConflictingRoles(mt, r)
 
 	if c.entity.types.Produced.Has(mt) {
 		Panicf(
@@ -112,8 +112,8 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 	c.entity.types.Produced.Add(mt, r)
 }
 
-// guardAgainstRoleMismatch panics if mt is already used in some role other than r.
-func (c *handlerConfigurer) guardAgainstRoleMismatch(mt message.Type, r message.Role) {
+// guardAgainstConflictingRoles panics if mt is already used in some role other than r.
+func (c *handlerConfigurer) guardAgainstConflictingRoles(mt message.Type, r message.Role) {
 	x, ok := c.entity.types.Roles[mt]
 
 	if !ok || x == r {

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -161,13 +161,3 @@ func (c *handlerConfigurer) mustProduce(r message.Role) {
 		strings.Title(r.String()),
 	)
 }
-
-func (c *handlerConfigurer) displayName() string {
-	s := c.entity.rt.String()
-
-	if !c.entity.ident.IsZero() {
-		s += " (" + c.entity.ident.Name + ")"
-	}
-
-	return s
-}

--- a/integration.go
+++ b/integration.go
@@ -37,7 +37,7 @@ func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 
 	c := &handlerConfigurer{
 		entityConfigurer: entityConfigurer{
-			target: &cfg.entity,
+			entity: &cfg.entity,
 		},
 	}
 

--- a/process.go
+++ b/process.go
@@ -37,7 +37,7 @@ func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 
 	c := &handlerConfigurer{
 		entityConfigurer: entityConfigurer{
-			target: &cfg.entity,
+			entity: &cfg.entity,
 		},
 	}
 

--- a/projection.go
+++ b/projection.go
@@ -37,7 +37,7 @@ func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 
 	c := &handlerConfigurer{
 		entityConfigurer: entityConfigurer{
-			target: &cfg.entity,
+			entity: &cfg.entity,
 		},
 	}
 


### PR DESCRIPTION
This PR adds the `FromApplication()` function, which builds a configuration for an application and all of its constituent handlers.

It includes another table-driven test for application errors, which deserve special attention.