### PR TITLE
Add `NewHandlerSet()` and `NewRichHandlerSet()`.

### DIFF
--- a/handlerset.go
+++ b/handlerset.go
@@ -5,6 +5,21 @@ import "github.com/dogmatiq/configkit/message"
 // HandlerSet is a collection of handlers.
 type HandlerSet map[Identity]Handler
 
+// NewHandlerSet returns a HandlerSet containing the given handlers.
+//
+// It panics if any of the handler identities conflict.
+func NewHandlerSet(handlers ...Handler) HandlerSet {
+	s := HandlerSet{}
+
+	for _, h := range handlers {
+		if !s.Add(h) {
+			panic("handler set contains conflicting identities")
+		}
+	}
+
+	return s
+}
+
 // Add adds a handler to the set.
 //
 // It returns true if the handler was added, or false if the set already
@@ -98,6 +113,21 @@ func (s HandlerSet) Filter(fn func(Handler) bool) HandlerSet {
 
 // RichHandlerSet is a collection of rich handlers.
 type RichHandlerSet map[Identity]RichHandler
+
+// NewRichHandlerSet returns a HandlerSet containing the given handlers.
+//
+// It panics if any of the handler identities conflict.
+func NewRichHandlerSet(handlers ...RichHandler) RichHandlerSet {
+	s := RichHandlerSet{}
+
+	for _, h := range handlers {
+		if !s.Add(h) {
+			panic("handler set contains conflicting identities")
+		}
+	}
+
+	return s
+}
 
 // Add adds a handler to the set.
 //

--- a/handlerset.go
+++ b/handlerset.go
@@ -114,7 +114,7 @@ func (s HandlerSet) Filter(fn func(Handler) bool) HandlerSet {
 // RichHandlerSet is a collection of rich handlers.
 type RichHandlerSet map[Identity]RichHandler
 
-// NewRichHandlerSet returns a HandlerSet containing the given handlers.
+// NewRichHandlerSet returns a RichHandlerSet containing the given handlers.
 //
 // It panics if any of the handler identities conflict.
 func NewRichHandlerSet(handlers ...RichHandler) RichHandlerSet {

--- a/handlerset_test.go
+++ b/handlerset_test.go
@@ -35,6 +35,24 @@ var _ = Describe("type HandlerSet", func() {
 		})
 	})
 
+	Describe("func NewHandlerSet()", func() {
+		It("returns a set containing the given handlers", func() {
+			s := NewHandlerSet(aggregate, projection)
+			Expect(s).To(HaveLen(2))
+			Expect(s.Has(aggregate)).To(BeTrue())
+			Expect(s.Has(projection)).To(BeTrue())
+		})
+
+		It("panics if the handler identities conflict", func() {
+			Expect(func() {
+				NewHandlerSet(
+					aggregate,
+					FromAggregate(aggregate.Handler()),
+				)
+			}).To(Panic())
+		})
+	})
+
 	Describe("func Add()", func() {
 		It("adds the handler to the set", func() {
 			ok := set.Add(aggregate)
@@ -215,6 +233,24 @@ var _ = Describe("type RichHandlerSet", func() {
 				c.Identity("<proj-name>", "<proj-key>")
 				c.ConsumesEventType(fixtures.MessageE{})
 			},
+		})
+	})
+
+	Describe("func NewRichHandlerSet()", func() {
+		It("returns a set containing the given handlers", func() {
+			s := NewRichHandlerSet(aggregate, projection)
+			Expect(s).To(HaveLen(2))
+			Expect(s.Has(aggregate)).To(BeTrue())
+			Expect(s.Has(projection)).To(BeTrue())
+		})
+
+		It("panics if the handler identities conflict", func() {
+			Expect(func() {
+				NewRichHandlerSet(
+					aggregate,
+					FromAggregate(aggregate.Handler()),
+				)
+			}).To(Panic())
 		})
 	})
 


### PR DESCRIPTION
This PR adds functions for constructing correctly formed handler sets.

They panic if any handler identities conflict, but this is **not** the user-facing error that an application-developer will see when configuring their application.