### PR TITLE
Pull generic code out of handler-specific configurer.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -29,15 +29,14 @@ type RichAggregate interface {
 // configuration related panic values to errors.
 func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 	cfg := &aggregate{
-		handler: handler{
+		entity: entity{
 			rt: reflect.TypeOf(h),
-			ht: AggregateHandlerType,
 		},
 		impl: h,
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.handler,
+		target: &cfg.entity,
 	}
 
 	h.Configure(c)
@@ -51,7 +50,8 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 
 // aggregate is an implementation of RichAggregate.
 type aggregate struct {
-	handler
+	entity
+
 	impl dogma.AggregateMessageHandler
 }
 
@@ -61,6 +61,10 @@ func (h *aggregate) AcceptVisitor(ctx context.Context, v Visitor) error {
 
 func (h *aggregate) AcceptRichVisitor(ctx context.Context, v RichVisitor) error {
 	return v.VisitRichAggregate(ctx, h)
+}
+
+func (h *aggregate) HandlerType() HandlerType {
+	return AggregateHandlerType
 }
 
 func (h *aggregate) Handler() dogma.AggregateMessageHandler {

--- a/aggregate.go
+++ b/aggregate.go
@@ -36,7 +36,9 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.entity,
+		entityConfigurer: entityConfigurer{
+			target: &cfg.entity,
+		},
 	}
 
 	h.Configure(c)

--- a/entity.go
+++ b/entity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/dogmatiq/configkit/internal/typename"
 	"github.com/dogmatiq/configkit/message"
 )
 
@@ -66,4 +67,33 @@ type EntityMessageTypes struct {
 
 	// Consumed is a set of message types consumed by the entity.
 	Consumed message.TypeSet
+}
+
+// entity is a partial implementation of RichEntity.
+type entity struct {
+	rt reflect.Type
+
+	ident Identity
+	names EntityMessageNames
+	types EntityMessageTypes
+}
+
+func (e *entity) Identity() Identity {
+	return e.ident
+}
+
+func (e *entity) MessageNames() EntityMessageNames {
+	return e.names
+}
+
+func (e *entity) MessageTypes() EntityMessageTypes {
+	return e.types
+}
+
+func (e *entity) TypeName() string {
+	return typename.Of(e.ReflectType())
+}
+
+func (e *entity) ReflectType() reflect.Type {
+	return e.rt
 }

--- a/entityconfigurer.go
+++ b/entityconfigurer.go
@@ -1,0 +1,48 @@
+package configkit
+
+// handlerConfigurer is a partial implementation of the configurer interfaces for
+// all of the Dogma entity types.
+//
+// - dogma.ApplicationConfigurer
+// - dogma.AggregateConfigurer
+// - dogma.ProcessConfigurer
+// - dogma.IntegrationConfigurer
+// - dogma.ProjectionConfigurer
+type entityConfigurer struct {
+	// target is the entity to populate with the configuration values.
+	target *entity
+}
+
+// Identity sets the handler's identity.
+func (c *entityConfigurer) Identity(name string, key string) {
+	if !c.target.ident.IsZero() {
+		Panicf(
+			"%s is configured with multiple identities (%s and %s/%s), Identity() must be called exactly once within Configure()",
+			c.target.rt.String(),
+			c.target.ident,
+			name,
+			key,
+		)
+	}
+
+	var err error
+	c.target.ident, err = NewIdentity(name, key)
+
+	if err != nil {
+		Panicf(
+			"%s is configured with an invalid identity, %s",
+			c.target.rt.String(),
+			err,
+		)
+	}
+}
+
+// validate panics if the configuration is invalid.
+func (c *entityConfigurer) validate() {
+	if c.target.ident.IsZero() {
+		Panicf(
+			"%s is configured without an identity, Identity() must be called exactly once within Configure()",
+			c.target.rt.String(),
+		)
+	}
+}

--- a/handler.go
+++ b/handler.go
@@ -1,11 +1,5 @@
 package configkit
 
-import (
-	"reflect"
-
-	"github.com/dogmatiq/configkit/internal/typename"
-)
-
 // Handler is a specialization of the Entity interface for message handlers.
 type Handler interface {
 	Entity
@@ -21,38 +15,4 @@ type RichHandler interface {
 
 	// HandlerType returns the type of handler.
 	HandlerType() HandlerType
-}
-
-// handler is a partial implementation of RichHandler.
-type handler struct {
-	rt reflect.Type
-	ht HandlerType
-
-	ident Identity
-	names EntityMessageNames
-	types EntityMessageTypes
-}
-
-func (h *handler) Identity() Identity {
-	return h.ident
-}
-
-func (h *handler) MessageNames() EntityMessageNames {
-	return h.names
-}
-
-func (h *handler) MessageTypes() EntityMessageTypes {
-	return h.types
-}
-
-func (h *handler) TypeName() string {
-	return typename.Of(h.ReflectType())
-}
-
-func (h *handler) ReflectType() reflect.Type {
-	return h.rt
-}
-
-func (h *handler) HandlerType() HandlerType {
-	return h.ht
 }

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -15,32 +15,7 @@ import (
 // - dogma.IntegrationConfigurer
 // - dogma.ProjectionConfigurer
 type handlerConfigurer struct {
-	// target is the entity to populate with the configuration values.
-	target *entity
-}
-
-// Identity sets the handler's identity.
-func (c *handlerConfigurer) Identity(name string, key string) {
-	if !c.target.ident.IsZero() {
-		Panicf(
-			"%s is configured with multiple identities (%s and %s/%s), Identity() must be called exactly once within Configure()",
-			c.target.rt.String(),
-			c.target.ident,
-			name,
-			key,
-		)
-	}
-
-	var err error
-	c.target.ident, err = NewIdentity(name, key)
-
-	if err != nil {
-		Panicf(
-			"%s is configured with an invalid identity, %s",
-			c.target.rt.String(),
-			err,
-		)
-	}
+	entityConfigurer
 }
 
 // ConsumesCommandTypes marks the handler as a consumer of command messages of
@@ -152,16 +127,6 @@ func (c *handlerConfigurer) guardAgainstRoleMismatch(mt message.Type, r message.
 		x,
 		r,
 	)
-}
-
-// validate panics if the configuration is invalid.
-func (c *handlerConfigurer) validate() {
-	if c.target.ident.IsZero() {
-		Panicf(
-			"%s is configured without an identity, Identity() must be called exactly once within Configure()",
-			c.target.rt.String(),
-		)
-	}
 }
 
 // mustConsume panics if the handler does not consume any messages of the given role.

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -15,8 +15,8 @@ import (
 // - dogma.IntegrationConfigurer
 // - dogma.ProjectionConfigurer
 type handlerConfigurer struct {
-	// target is the handler to populate with the configuration values.
-	target *handler
+	// target is the entity to populate with the configuration values.
+	target *entity
 }
 
 // Identity sets the handler's identity.

--- a/integration.go
+++ b/integration.go
@@ -36,7 +36,9 @@ func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.entity,
+		entityConfigurer: entityConfigurer{
+			target: &cfg.entity,
+		},
 	}
 
 	h.Configure(c)

--- a/integration.go
+++ b/integration.go
@@ -29,15 +29,14 @@ type RichIntegration interface {
 // configuration related panic values to errors.
 func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 	cfg := &integration{
-		handler: handler{
+		entity: entity{
 			rt: reflect.TypeOf(h),
-			ht: IntegrationHandlerType,
 		},
 		impl: h,
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.handler,
+		target: &cfg.entity,
 	}
 
 	h.Configure(c)
@@ -50,7 +49,8 @@ func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 
 // integration is an implementation of RichIntegration.
 type integration struct {
-	handler
+	entity
+
 	impl dogma.IntegrationMessageHandler
 }
 
@@ -60,6 +60,10 @@ func (h *integration) AcceptVisitor(ctx context.Context, v Visitor) error {
 
 func (h *integration) AcceptRichVisitor(ctx context.Context, v RichVisitor) error {
 	return v.VisitRichIntegration(ctx, h)
+}
+
+func (h *integration) HandlerType() HandlerType {
+	return IntegrationHandlerType
 }
 
 func (h *integration) Handler() dogma.IntegrationMessageHandler {

--- a/process.go
+++ b/process.go
@@ -29,15 +29,14 @@ type RichProcess interface {
 // configuration related panic values to errors.
 func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 	cfg := &process{
-		handler: handler{
+		entity: entity{
 			rt: reflect.TypeOf(h),
-			ht: ProcessHandlerType,
 		},
 		impl: h,
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.handler,
+		target: &cfg.entity,
 	}
 
 	h.Configure(c)
@@ -51,7 +50,8 @@ func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 
 // process is an implementation of RichProcess.
 type process struct {
-	handler
+	entity
+
 	impl dogma.ProcessMessageHandler
 }
 
@@ -61,6 +61,10 @@ func (h *process) AcceptVisitor(ctx context.Context, v Visitor) error {
 
 func (h *process) AcceptRichVisitor(ctx context.Context, v RichVisitor) error {
 	return v.VisitRichProcess(ctx, h)
+}
+
+func (h *process) HandlerType() HandlerType {
+	return ProcessHandlerType
 }
 
 func (h *process) Handler() dogma.ProcessMessageHandler {

--- a/process.go
+++ b/process.go
@@ -36,7 +36,9 @@ func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.entity,
+		entityConfigurer: entityConfigurer{
+			target: &cfg.entity,
+		},
 	}
 
 	h.Configure(c)

--- a/projection.go
+++ b/projection.go
@@ -36,7 +36,9 @@ func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.entity,
+		entityConfigurer: entityConfigurer{
+			target: &cfg.entity,
+		},
 	}
 
 	h.Configure(c)

--- a/projection.go
+++ b/projection.go
@@ -29,15 +29,14 @@ type RichProjection interface {
 // configuration related panic values to errors.
 func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 	cfg := &projection{
-		handler: handler{
+		entity: entity{
 			rt: reflect.TypeOf(h),
-			ht: ProjectionHandlerType,
 		},
 		impl: h,
 	}
 
 	c := &handlerConfigurer{
-		target: &cfg.handler,
+		target: &cfg.entity,
 	}
 
 	h.Configure(c)
@@ -50,7 +49,8 @@ func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 
 // projection is an implementation of RichProjection.
 type projection struct {
-	handler
+	entity
+
 	impl dogma.ProjectionMessageHandler
 }
 
@@ -60,6 +60,10 @@ func (h *projection) AcceptVisitor(ctx context.Context, v Visitor) error {
 
 func (h *projection) AcceptRichVisitor(ctx context.Context, v RichVisitor) error {
 	return v.VisitRichProjection(ctx, h)
+}
+
+func (h *projection) HandlerType() HandlerType {
+	return ProjectionHandlerType
 }
 
 func (h *projection) Handler() dogma.ProjectionMessageHandler {


### PR DESCRIPTION
Some of the code from `handlerConfigurer` and basically all of `handler` can be reused for applications as well as handlers.

This PR pulls those elements out into reusable components in preparation for the application configuration implementation in #13.