### PR TITLE
Use `NameRoles` and `TypeRoles` instead of plain sets entity message collections.

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -53,13 +53,13 @@ var _ = Describe("func FromAggregate()", func() {
 							cfixtures.MessageBTypeName: message.CommandRole,
 							cfixtures.MessageETypeName: message.EventRole,
 						},
-						Produced: message.NewNameSet(
-							cfixtures.MessageETypeName,
-						),
-						Consumed: message.NewNameSet(
-							cfixtures.MessageATypeName,
-							cfixtures.MessageBTypeName,
-						),
+						Produced: message.NameRoles{
+							cfixtures.MessageETypeName: message.EventRole,
+						},
+						Consumed: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.CommandRole,
+						},
 					},
 				))
 			})
@@ -74,13 +74,13 @@ var _ = Describe("func FromAggregate()", func() {
 							cfixtures.MessageBType: message.CommandRole,
 							cfixtures.MessageEType: message.EventRole,
 						},
-						Produced: message.NewTypeSet(
-							cfixtures.MessageEType,
-						),
-						Consumed: message.NewTypeSet(
-							cfixtures.MessageAType,
-							cfixtures.MessageBType,
-						),
+						Produced: message.TypeRoles{
+							cfixtures.MessageEType: message.EventRole,
+						},
+						Consumed: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.CommandRole,
+						},
 					},
 				))
 			})

--- a/entity.go
+++ b/entity.go
@@ -50,10 +50,10 @@ type EntityMessageNames struct {
 	Roles message.NameRoles
 
 	// Produced is a set of message names produced by the entity.
-	Produced message.NameSet
+	Produced message.NameRoles
 
 	// Consumed is a set of message names consumed by the entity.
-	Consumed message.NameSet
+	Consumed message.NameRoles
 }
 
 // EntityMessageTypes describes how messages are used within a Dogma entity
@@ -63,10 +63,10 @@ type EntityMessageTypes struct {
 	Roles message.TypeRoles
 
 	// Produced is a set of message types produced by the entity.
-	Produced message.TypeSet
+	Produced message.TypeRoles
 
 	// Consumed is a set of message types consumed by the entity.
-	Consumed message.TypeSet
+	Consumed message.TypeRoles
 }
 
 // entity is a partial implementation of RichEntity.

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -70,15 +70,15 @@ func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb strin
 	}
 
 	if c.target.names.Consumed == nil {
-		c.target.names.Consumed = message.NameSet{}
-		c.target.types.Consumed = message.TypeSet{}
+		c.target.names.Consumed = message.NameRoles{}
+		c.target.types.Consumed = message.TypeRoles{}
 	}
 
 	n := mt.Name()
-	c.target.names.Roles[n] = r
-	c.target.names.Consumed.Add(n)
-	c.target.types.Roles[mt] = r
-	c.target.types.Consumed.Add(mt)
+	c.target.names.Roles.Add(n, r)
+	c.target.names.Consumed.Add(n, r)
+	c.target.types.Roles.Add(mt, r)
+	c.target.types.Consumed.Add(mt, r)
 }
 
 // produces marks the handler as a consumer of messages of the same type as m.
@@ -101,15 +101,15 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 	}
 
 	if c.target.names.Produced == nil {
-		c.target.names.Produced = message.NameSet{}
-		c.target.types.Produced = message.TypeSet{}
+		c.target.names.Produced = message.NameRoles{}
+		c.target.types.Produced = message.TypeRoles{}
 	}
 
 	n := mt.Name()
-	c.target.names.Roles[n] = r
-	c.target.names.Produced.Add(n)
-	c.target.types.Roles[mt] = r
-	c.target.types.Produced.Add(mt)
+	c.target.names.Roles.Add(n, r)
+	c.target.names.Produced.Add(n, r)
+	c.target.types.Roles.Add(mt, r)
+	c.target.types.Produced.Add(mt, r)
 }
 
 // guardAgainstRoleMismatch panics if mt is already used in some role other than r.

--- a/integration_test.go
+++ b/integration_test.go
@@ -53,13 +53,13 @@ var _ = Describe("func FromIntegration()", func() {
 							cfixtures.MessageBTypeName: message.CommandRole,
 							cfixtures.MessageETypeName: message.EventRole,
 						},
-						Produced: message.NewNameSet(
-							cfixtures.MessageETypeName,
-						),
-						Consumed: message.NewNameSet(
-							cfixtures.MessageATypeName,
-							cfixtures.MessageBTypeName,
-						),
+						Produced: message.NameRoles{
+							cfixtures.MessageETypeName: message.EventRole,
+						},
+						Consumed: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.CommandRole,
+						},
 					},
 				))
 			})
@@ -74,13 +74,13 @@ var _ = Describe("func FromIntegration()", func() {
 							cfixtures.MessageBType: message.CommandRole,
 							cfixtures.MessageEType: message.EventRole,
 						},
-						Produced: message.NewTypeSet(
-							cfixtures.MessageEType,
-						),
-						Consumed: message.NewTypeSet(
-							cfixtures.MessageAType,
-							cfixtures.MessageBType,
-						),
+						Produced: message.TypeRoles{
+							cfixtures.MessageEType: message.EventRole,
+						},
+						Consumed: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.CommandRole,
+						},
 					},
 				))
 			})

--- a/process_test.go
+++ b/process_test.go
@@ -55,15 +55,15 @@ var _ = Describe("func FromProcess()", func() {
 							cfixtures.MessageCTypeName: message.CommandRole,
 							cfixtures.MessageTTypeName: message.TimeoutRole,
 						},
-						Produced: message.NewNameSet(
-							cfixtures.MessageCTypeName,
-							cfixtures.MessageTTypeName,
-						),
-						Consumed: message.NewNameSet(
-							cfixtures.MessageATypeName,
-							cfixtures.MessageBTypeName,
-							cfixtures.MessageTTypeName,
-						),
+						Produced: message.NameRoles{
+							cfixtures.MessageCTypeName: message.CommandRole,
+							cfixtures.MessageTTypeName: message.TimeoutRole,
+						},
+						Consumed: message.NameRoles{
+							cfixtures.MessageATypeName: message.EventRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+							cfixtures.MessageTTypeName: message.TimeoutRole,
+						},
 					},
 				))
 			})
@@ -79,15 +79,15 @@ var _ = Describe("func FromProcess()", func() {
 							cfixtures.MessageCType: message.CommandRole,
 							cfixtures.MessageTType: message.TimeoutRole,
 						},
-						Produced: message.NewTypeSet(
-							cfixtures.MessageCType,
-							cfixtures.MessageTType,
-						),
-						Consumed: message.NewTypeSet(
-							cfixtures.MessageAType,
-							cfixtures.MessageBType,
-							cfixtures.MessageTType,
-						),
+						Produced: message.TypeRoles{
+							cfixtures.MessageCType: message.CommandRole,
+							cfixtures.MessageTType: message.TimeoutRole,
+						},
+						Consumed: message.TypeRoles{
+							cfixtures.MessageAType: message.EventRole,
+							cfixtures.MessageBType: message.EventRole,
+							cfixtures.MessageTType: message.TimeoutRole,
+						},
 					},
 				))
 			})

--- a/projection_test.go
+++ b/projection_test.go
@@ -52,10 +52,10 @@ var _ = Describe("func FromProjection()", func() {
 							cfixtures.MessageBTypeName: message.EventRole,
 						},
 						Produced: nil,
-						Consumed: message.NewNameSet(
-							cfixtures.MessageATypeName,
-							cfixtures.MessageBTypeName,
-						),
+						Consumed: message.NameRoles{
+							cfixtures.MessageATypeName: message.EventRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+						},
 					},
 				))
 			})
@@ -70,10 +70,10 @@ var _ = Describe("func FromProjection()", func() {
 							cfixtures.MessageBType: message.EventRole,
 						},
 						Produced: nil,
-						Consumed: message.NewTypeSet(
-							cfixtures.MessageAType,
-							cfixtures.MessageBType,
-						),
+						Consumed: message.TypeRoles{
+							cfixtures.MessageAType: message.EventRole,
+							cfixtures.MessageBType: message.EventRole,
+						},
 					},
 				))
 			})


### PR DESCRIPTION
These collection types share the same interface anyway, it just makes it easier if you want access to the "role" why iterating.