### PR TITLE
Convert enumerations to use string as an underlying type.

### DIFF
--- a/handlertype_test.go
+++ b/handlertype_test.go
@@ -18,7 +18,7 @@ var _ = Describe("type HandlerType", func() {
 
 		It("panics when the type is not valid", func() {
 			Expect(func() {
-				HandlerType(0).MustValidate()
+				HandlerType("<invalid>").MustValidate()
 			}).To(Panic())
 		})
 	})
@@ -152,7 +152,7 @@ var _ = Describe("type HandlerType", func() {
 			Expect(ProcessHandlerType.String()).To(Equal("process"))
 			Expect(IntegrationHandlerType.String()).To(Equal("integration"))
 			Expect(ProjectionHandlerType.String()).To(Equal("projection"))
-			Expect(HandlerType(0).String()).To(Equal("<invalid handler type 0x0>"))
+			Expect(HandlerType("<invalid>").String()).To(Equal("<invalid handler type: <invalid>>"))
 		})
 	})
 
@@ -165,7 +165,7 @@ var _ = Describe("type HandlerType", func() {
 		})
 
 		It("returns an error if the type is invalid", func() {
-			_, err := HandlerType(0).MarshalText()
+			_, err := HandlerType("<invalid>").MarshalText()
 			Expect(err).Should(HaveOccurred())
 		})
 	})
@@ -208,7 +208,7 @@ var _ = Describe("type HandlerType", func() {
 		})
 
 		It("returns an error if the type is invalid", func() {
-			_, err := HandlerType(0).MarshalBinary()
+			_, err := HandlerType("<invalid>").MarshalBinary()
 			Expect(err).Should(HaveOccurred())
 		})
 	})

--- a/message/role.go
+++ b/message/role.go
@@ -137,7 +137,7 @@ func (r Role) MarshalText() ([]byte, error) {
 func (r *Role) UnmarshalText(text []byte) error {
 	x := Role(text)
 
-	if err := x.Validate(); err != nil {
+	if x.Validate() != nil {
 		return fmt.Errorf("invalid text representation of message role: %s", text)
 	}
 

--- a/message/role_test.go
+++ b/message/role_test.go
@@ -16,7 +16,7 @@ var _ = Describe("type Role", func() {
 
 		It("panics when the role is not valid", func() {
 			Expect(func() {
-				Role(0).MustValidate()
+				Role("<invalid>").MustValidate()
 			}).To(Panic())
 		})
 	})
@@ -76,7 +76,7 @@ var _ = Describe("type Role", func() {
 			Expect(CommandRole.String()).To(Equal("command"))
 			Expect(EventRole.String()).To(Equal("event"))
 			Expect(TimeoutRole.String()).To(Equal("timeout"))
-			Expect(Role(0).String()).To(Equal("<invalid message role 0x0>"))
+			Expect(Role("<invalid>").String()).To(Equal("<invalid message role: <invalid>>"))
 		})
 	})
 
@@ -88,7 +88,7 @@ var _ = Describe("type Role", func() {
 		})
 
 		It("returns an error if the role is invalid", func() {
-			_, err := Role(0).MarshalText()
+			_, err := Role("<invalid>").MarshalText()
 			Expect(err).Should(HaveOccurred())
 		})
 	})
@@ -126,7 +126,7 @@ var _ = Describe("type Role", func() {
 		})
 
 		It("returns an error if the role is invalid", func() {
-			_, err := Role(0).MarshalBinary()
+			_, err := Role("<invalid>").MarshalBinary()
 			Expect(err).Should(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
This makes it easier to understand when you print these values or see them in failed test assertions.

Fixes #11