### PR TITLE
Omit handler names from error messages if the identity is not configured.

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -244,5 +244,13 @@ var _ = Describe("func FromAggregate()", func() {
 				c.ProducesEventType(fixtures.MessageA{})
 			},
 		),
+		Entry(
+			"when an error occurs before the identity is configured it omits the handler name",
+			`*fixtures.AggregateMessageHandler is configured to consume the fixtures.MessageA command more than once, should this refer to different message types?`,
+			func(c dogma.AggregateConfigurer) {
+				c.ConsumesCommandType(fixtures.MessageA{})
+				c.ConsumesCommandType(fixtures.MessageA{})
+			},
+		),
 	)
 })

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -56,9 +56,8 @@ func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb strin
 
 	if c.target.types.Consumed.Has(mt) {
 		Panicf(
-			"%s (%s) is configured to %s the %s %s more than once, should this refer to different message types?",
-			c.target.rt,
-			c.target.ident.Name,
+			"%s is configured to %s the %s %s more than once, should this refer to different message types?",
+			c.displayName(),
 			verb,
 			mt,
 			r,
@@ -89,9 +88,8 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 
 	if c.target.types.Produced.Has(mt) {
 		Panicf(
-			"%s (%s) is configured to %s the %s %s more than once, should this refer to different message types?",
-			c.target.rt,
-			c.target.ident.Name,
+			"%s is configured to %s the %s %s more than once, should this refer to different message types?",
+			c.displayName(),
 			verb,
 			mt,
 			r,
@@ -123,9 +121,8 @@ func (c *handlerConfigurer) guardAgainstRoleMismatch(mt message.Type, r message.
 	}
 
 	Panicf(
-		"%s (%s) is configured to use %s as both a %s and a %s",
-		c.target.rt,
-		c.target.ident.Name,
+		"%s is configured to use %s as both a %s and a %s",
+		c.displayName(),
 		mt,
 		x,
 		r,
@@ -158,10 +155,19 @@ func (c *handlerConfigurer) mustProduce(r message.Role) {
 	}
 
 	Panicf(
-		`%s (%s) is not configured to produce any %ss, Produces%sType() must be called at least once within Configure()`,
-		c.target.rt,
-		c.target.ident.Name,
+		`%s is not configured to produce any %ss, Produces%sType() must be called at least once within Configure()`,
+		c.displayName(),
 		r,
 		strings.Title(r.String()),
 	)
+}
+
+func (c *handlerConfigurer) displayName() string {
+	s := c.target.rt.String()
+
+	if !c.target.ident.IsZero() {
+		s += " (" + c.target.ident.Name + ")"
+	}
+
+	return s
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -249,5 +249,13 @@ var _ = Describe("func FromIntegration()", func() {
 				c.ProducesEventType(fixtures.MessageA{})
 			},
 		),
+		Entry(
+			"when an error occurs before the identity is configured it omits the handler name",
+			`*fixtures.IntegrationMessageHandler is configured to consume the fixtures.MessageA command more than once, should this refer to different message types?`,
+			func(c dogma.IntegrationConfigurer) {
+				c.ConsumesCommandType(fixtures.MessageA{})
+				c.ConsumesCommandType(fixtures.MessageA{})
+			},
+		),
 	)
 })

--- a/process_test.go
+++ b/process_test.go
@@ -262,5 +262,13 @@ var _ = Describe("func FromProcess()", func() {
 				c.SchedulesTimeoutType(fixtures.MessageA{})
 			},
 		),
+		Entry(
+			"when an error occurs before the identity is configured it omits the handler name",
+			`*fixtures.ProcessMessageHandler is configured to consume the fixtures.MessageA event more than once, should this refer to different message types?`,
+			func(c dogma.ProcessConfigurer) {
+				c.ConsumesEventType(fixtures.MessageA{})
+				c.ConsumesEventType(fixtures.MessageA{})
+			},
+		),
 	)
 })

--- a/projection_test.go
+++ b/projection_test.go
@@ -204,5 +204,13 @@ var _ = Describe("func FromProjection()", func() {
 				c.ConsumesEventType(fixtures.MessageA{})
 			},
 		),
+		Entry(
+			"when an error occurs before the identity is configured it omits the handler name",
+			`*fixtures.ProjectionMessageHandler is configured to consume the fixtures.MessageA event more than once, should this refer to different message types?`,
+			func(c dogma.ProjectionConfigurer) {
+				c.ConsumesEventType(fixtures.MessageA{})
+				c.ConsumesEventType(fixtures.MessageA{})
+			},
+		),
 	)
 })


### PR DESCRIPTION
This PR updates the handler-related error messages to refer to the handlers by their Go type, only adding the handler name if it's actually set via `Identity()`.  

This is necessary as Dogma does not require the handler to be configured in any particular order - that is, it's ok to configure the routes before the identity.  