### PR TITLE
Remove ambiguity about the "direction" of foreign messages.

### DIFF
--- a/application.go
+++ b/application.go
@@ -128,6 +128,7 @@ func (a *application) Application() dogma.Application {
 	return a.impl
 }
 
+// initForeign initializes a.foreignNames and a.foreignTypes.
 func (a *application) initForeign() {
 	a.foreignNames = EntityMessageNames{
 		Roles:    message.NameRoles{},
@@ -146,15 +147,15 @@ func (a *application) initForeign() {
 			continue
 		}
 
-		if r != message.CommandRole {
-			continue
+		// Commands MUST always have a handler. Therefore, any command that is
+		// produced by this application, but not consumed by this application is
+		// considered foreign.
+		if r == message.CommandRole {
+			a.foreignNames.Roles.Add(mt.Name(), r)
+			a.foreignTypes.Roles.Add(mt, r)
+			a.foreignNames.Produced.Add(mt.Name(), r)
+			a.foreignTypes.Produced.Add(mt, r)
 		}
-
-		a.foreignNames.Roles.Add(mt.Name(), r)
-		a.foreignTypes.Roles.Add(mt, r)
-
-		a.foreignNames.Produced.Add(mt.Name(), r)
-		a.foreignTypes.Produced.Add(mt, r)
 	}
 
 	for mt, r := range a.entity.types.Consumed {
@@ -162,9 +163,10 @@ func (a *application) initForeign() {
 			continue
 		}
 
+		// Any message type is considered foreign if it needs to be obtained from
+		// elsewhere.
 		a.foreignNames.Roles.Add(mt.Name(), r)
 		a.foreignTypes.Roles.Add(mt, r)
-
 		a.foreignNames.Consumed.Add(mt.Name(), r)
 		a.foreignTypes.Consumed.Add(mt, r)
 	}

--- a/application.go
+++ b/application.go
@@ -17,7 +17,12 @@ type Application interface {
 	Handlers() HandlerSet
 
 	// ForeignMessageNames returns the message names that this application
-	// uses that must be communicated to some other Dogma application.
+	// uses that must be communicated beyond the scope of the application.
+	//
+	// This includes:
+	//	- commands that are produced by this application, but consumed elsewhere
+	//	- commands that are consumed by this application, but produced elsewhere
+	//	- events that are consumed by this application, but produced elsewhere
 	ForeignMessageNames() message.NameRoles
 }
 
@@ -33,11 +38,21 @@ type RichApplication interface {
 	RichHandlers() RichHandlerSet
 
 	// ForeignMessageNames returns the message names that this application
-	// uses that must be communicated to some other Dogma application.
+	// uses that must be communicated beyond the scope of the application.
+	//
+	// This includes:
+	//	- commands that are produced by this application, but consumed elsewhere
+	//	- commands that are consumed by this application, but produced elsewhere
+	//	- events that are consumed by this application, but produced elsewhere
 	ForeignMessageNames() message.NameRoles
 
 	// ForeignMessageTypes returns the message types that this application
-	// uses that must be communicated to some other Dogma application.
+	// uses that must be communicated beyond the scope of the application.
+	//
+	// This includes:
+	//	- commands that are produced by this application, but consumed elsewhere
+	//	- commands that are consumed by this application, but produced elsewhere
+	//	- events that are consumed by this application, but produced elsewhere
 	ForeignMessageTypes() message.TypeRoles
 
 	// Application returns the underlying application.

--- a/application_test.go
+++ b/application_test.go
@@ -223,11 +223,21 @@ var _ = Describe("func FromApplication()", func() {
 		Describe("func ForeignMessageNames()", func() {
 			It("returns the set of messages that belong to another application", func() {
 				Expect(cfg.ForeignMessageNames()).To(Equal(
-					message.NameRoles{
-						cfixtures.MessageATypeName: message.CommandRole,
-						cfixtures.MessageBTypeName: message.EventRole,
-						cfixtures.MessageDTypeName: message.EventRole,
-						cfixtures.MessageXTypeName: message.CommandRole,
+					EntityMessageNames{
+						Roles: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+							cfixtures.MessageDTypeName: message.EventRole,
+							cfixtures.MessageXTypeName: message.CommandRole,
+						},
+						Produced: message.NameRoles{
+							cfixtures.MessageXTypeName: message.CommandRole,
+						},
+						Consumed: message.NameRoles{
+							cfixtures.MessageATypeName: message.CommandRole,
+							cfixtures.MessageBTypeName: message.EventRole,
+							cfixtures.MessageDTypeName: message.EventRole,
+						},
 					},
 				))
 			})
@@ -236,11 +246,21 @@ var _ = Describe("func FromApplication()", func() {
 		Describe("func ForeignMessageTypes()", func() {
 			It("returns the set of messages that belong to another application", func() {
 				Expect(cfg.ForeignMessageTypes()).To(Equal(
-					message.TypeRoles{
-						cfixtures.MessageAType: message.CommandRole,
-						cfixtures.MessageBType: message.EventRole,
-						cfixtures.MessageDType: message.EventRole,
-						cfixtures.MessageXType: message.CommandRole,
+					EntityMessageTypes{
+						Roles: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.EventRole,
+							cfixtures.MessageDType: message.EventRole,
+							cfixtures.MessageXType: message.CommandRole,
+						},
+						Produced: message.TypeRoles{
+							cfixtures.MessageXType: message.CommandRole,
+						},
+						Consumed: message.TypeRoles{
+							cfixtures.MessageAType: message.CommandRole,
+							cfixtures.MessageBType: message.EventRole,
+							cfixtures.MessageDType: message.EventRole,
+						},
 					},
 				))
 			})

--- a/application_test.go
+++ b/application_test.go
@@ -28,7 +28,7 @@ var _ = Describe("func FromApplication()", func() {
 		aggregate = &fixtures.AggregateMessageHandler{
 			ConfigureFunc: func(c dogma.AggregateConfigurer) {
 				c.Identity("<aggregate>", "<aggregate-key>")
-				c.ConsumesCommandType(fixtures.MessageA{})
+				c.ConsumesCommandType(fixtures.MessageA{}) // foreign produced command
 				c.ProducesEventType(fixtures.MessageE{})
 			},
 		}
@@ -36,10 +36,10 @@ var _ = Describe("func FromApplication()", func() {
 		process = &fixtures.ProcessMessageHandler{
 			ConfigureFunc: func(c dogma.ProcessConfigurer) {
 				c.Identity("<process>", "<process-key>")
-				c.ConsumesEventType(fixtures.MessageB{}) // foreign event
+				c.ConsumesEventType(fixtures.MessageB{}) // foreign produced event
 				c.ConsumesEventType(fixtures.MessageE{}) // shared with <projection>
 				c.ProducesCommandType(fixtures.MessageC{})
-				c.ProducesCommandType(fixtures.MessageX{}) // foreign command
+				c.ProducesCommandType(fixtures.MessageX{}) // foreign consumed command
 				c.SchedulesTimeoutType(fixtures.MessageT{})
 			},
 		}
@@ -224,6 +224,7 @@ var _ = Describe("func FromApplication()", func() {
 			It("returns the set of messages that belong to another application", func() {
 				Expect(cfg.ForeignMessageNames()).To(Equal(
 					message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
 						cfixtures.MessageBTypeName: message.EventRole,
 						cfixtures.MessageDTypeName: message.EventRole,
 						cfixtures.MessageXTypeName: message.CommandRole,
@@ -236,6 +237,7 @@ var _ = Describe("func FromApplication()", func() {
 			It("returns the set of messages that belong to another application", func() {
 				Expect(cfg.ForeignMessageTypes()).To(Equal(
 					message.TypeRoles{
+						cfixtures.MessageAType: message.CommandRole,
 						cfixtures.MessageBType: message.EventRole,
 						cfixtures.MessageDType: message.EventRole,
 						cfixtures.MessageXType: message.CommandRole,

--- a/applicationconfigurer.go
+++ b/applicationconfigurer.go
@@ -92,23 +92,6 @@ func (c *applicationConfigurer) register(h RichHandler) {
 	}
 }
 
-// validate panics if the configuration is invalid.
-func (c *applicationConfigurer) validate() {
-	c.entityConfigurer.validate()
-
-	for mt, r := range c.entity.types.Roles {
-		if c.isForeign(mt, r) {
-			if c.app.foreignNames == nil {
-				c.app.foreignNames = message.NameRoles{}
-				c.app.foreignTypes = message.TypeRoles{}
-			}
-
-			c.app.foreignNames.Add(mt.Name(), r)
-			c.app.foreignTypes.Add(mt, r)
-		}
-	}
-}
-
 // isForeign returns true if mt is "foreign", meaning that it needs to be
 // obtained from or sent outside the application.
 func (c *applicationConfigurer) isForeign(mt message.Type, r message.Role) bool {

--- a/applicationconfigurer.go
+++ b/applicationconfigurer.go
@@ -110,19 +110,22 @@ func (c *applicationConfigurer) validate() {
 }
 
 // isForeign returns true if mt is "foreign", meaning that it needs to be
-// obtained from or sent to a different application.
+// obtained from or sent outside the application.
 func (c *applicationConfigurer) isForeign(mt message.Type, r message.Role) bool {
 	produced := c.entity.types.Produced.Has(mt)
 	consumed := c.entity.types.Consumed.Has(mt)
 
-	switch r {
-	case message.CommandRole:
-		return produced && !consumed
-	case message.EventRole:
-		return consumed && !produced
-	default:
-		return false
+	// Commands must always have a handler, therefore any command that is not
+	// both produced and consumed by this application is considered foreign.
+	if r == message.CommandRole {
+		return produced != consumed
 	}
+
+	// Events that are only considered foreign if they need to be obtained from
+	// elsewhere. There is no requirement that a given event MUST have a
+	// handler, therefore any events produced by this app but not consumed are
+	// not considered foreign.
+	return consumed && !produced
 }
 
 // guardAgainstConflictingIdentities panics if h's identity conflicts with the

--- a/applicationconfigurer.go
+++ b/applicationconfigurer.go
@@ -92,25 +92,6 @@ func (c *applicationConfigurer) register(h RichHandler) {
 	}
 }
 
-// isForeign returns true if mt is "foreign", meaning that it needs to be
-// obtained from or sent outside the application.
-func (c *applicationConfigurer) isForeign(mt message.Type, r message.Role) bool {
-	produced := c.entity.types.Produced.Has(mt)
-	consumed := c.entity.types.Consumed.Has(mt)
-
-	// Commands must always have a handler, therefore any command that is not
-	// both produced and consumed by this application is considered foreign.
-	if r == message.CommandRole {
-		return produced != consumed
-	}
-
-	// Events that are only considered foreign if they need to be obtained from
-	// elsewhere. There is no requirement that a given event MUST have a
-	// handler, therefore any events produced by this app but not consumed are
-	// not considered foreign.
-	return consumed && !produced
-}
-
 // guardAgainstConflictingIdentities panics if h's identity conflicts with the
 // application or any other handlers.
 func (c *applicationConfigurer) guardAgainstConflictingIdentities(h RichHandler) {


### PR DESCRIPTION
This PR changes the `Application.ForeignMessageNames()` to return `EntityMessageNames` instead of a single `NameRoles` map.

`EntityMessageNames` contains explicit fields for the messages that are produced, vs those that are consumed. This is important because prior to this change it was unclear whether a foreign message was "coming in to" or "going out of" this application without comparing the result of `ForeignMessageNames()` to the result of `MessageNames()`.

An equivalent change has been made to `RichApplication.ForeignMessageTypes()`.

Additional, this PR fixes #21, which in turn caught an issue where commands consumed by a foreign application were not detected at all.

---

As an additional implementation detail change, the results of `ForeignMessageNames()` and `ForeignMessageTypes()` are now computed lazily.
