### PR TITLE
Allow configurations to be compared.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Add `NameSet.IsEqual()`
 - Add `TypeRoles.IsEqual()`
 - Add `TypeSet.IsEqual()`
+- Add `EntityMessageNames.IsEqual()`
 - Add `EntityMessageTypes.IsEqual()`
 
 ## [0.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Add `NameSet.IsEqual()`
 - Add `TypeRoles.IsEqual()`
 - Add `TypeSet.IsEqual()`
+- Add `EntityMessageTypes.IsEqual()`
 
 ## [0.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `TypeSet.IsEqual()`
+
 ## [0.1.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `NameSet.IsEqual()`
+- Add `TypeRoles.IsEqual()`
 - Add `TypeSet.IsEqual()`
 
 ## [0.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- Add `NameSet.IsEqual()`
 - Add `TypeSet.IsEqual()`
 
 ## [0.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- Add `NameRoles.IsEqual()`
 - Add `NameSet.IsEqual()`
 - Add `TypeRoles.IsEqual()`
 - Add `TypeSet.IsEqual()`

--- a/entity.go
+++ b/entity.go
@@ -69,6 +69,13 @@ type EntityMessageTypes struct {
 	Consumed message.TypeRoles
 }
 
+// IsEqual returns true if m is equal to o.
+func (m EntityMessageTypes) IsEqual(o EntityMessageTypes) bool {
+	return m.Roles.IsEqual(o.Roles) &&
+		m.Produced.IsEqual(o.Produced) &&
+		m.Consumed.IsEqual(o.Consumed)
+}
+
 // entity is a partial implementation of RichEntity.
 type entity struct {
 	rt reflect.Type

--- a/entity.go
+++ b/entity.go
@@ -56,6 +56,13 @@ type EntityMessageNames struct {
 	Consumed message.NameRoles
 }
 
+// IsEqual returns true if m is equal to o.
+func (m EntityMessageNames) IsEqual(o EntityMessageNames) bool {
+	return m.Roles.IsEqual(o.Roles) &&
+		m.Produced.IsEqual(o.Produced) &&
+		m.Consumed.IsEqual(o.Consumed)
+}
+
 // EntityMessageTypes describes how messages are used within a Dogma entity
 // where each message is identified by its type.
 type EntityMessageTypes struct {

--- a/entity_test.go
+++ b/entity_test.go
@@ -1,0 +1,111 @@
+package configkit_test
+
+import (
+	. "github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/fixtures" // can't dot-import due to conflicts
+	"github.com/dogmatiq/configkit/message"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type EntityMessageTypes", func() {
+	Describe("func IsEqual()", func() {
+		It("returns true if the sets are equivalent", func() {
+			a := EntityMessageTypes{
+				Roles: message.TypeRoles{
+					fixtures.MessageAType: message.CommandRole,
+					fixtures.MessageBType: message.EventRole,
+				},
+				Produced: message.TypeRoles{
+					fixtures.MessageBType: message.EventRole,
+				},
+				Consumed: message.TypeRoles{
+					fixtures.MessageAType: message.CommandRole,
+				},
+			}
+
+			b := EntityMessageTypes{
+				Roles: message.TypeRoles{
+					fixtures.MessageAType: message.CommandRole,
+					fixtures.MessageBType: message.EventRole,
+				},
+				Produced: message.TypeRoles{
+					fixtures.MessageBType: message.EventRole,
+				},
+				Consumed: message.TypeRoles{
+					fixtures.MessageAType: message.CommandRole,
+				},
+			}
+
+			Expect(a.IsEqual(b)).To(BeTrue())
+		})
+
+		DescribeTable(
+			"returns false if the sets are not equivalent",
+			func(b EntityMessageTypes) {
+				a := EntityMessageTypes{
+					Roles: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+						fixtures.MessageBType: message.EventRole,
+					},
+					Produced: message.TypeRoles{
+						fixtures.MessageBType: message.EventRole,
+					},
+					Consumed: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+					},
+				}
+				Expect(a.IsEqual(b)).To(BeFalse())
+			},
+			Entry(
+				"roles differ",
+				EntityMessageTypes{
+					Roles: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+						fixtures.MessageBType: message.EventRole,
+						fixtures.MessageCType: message.TimeoutRole, // diff
+					},
+					Produced: message.TypeRoles{
+						fixtures.MessageBType: message.EventRole,
+					},
+					Consumed: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+					},
+				},
+			),
+			Entry(
+				"produced messages differ",
+				EntityMessageTypes{
+					Roles: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+						fixtures.MessageBType: message.EventRole,
+					},
+					Produced: message.TypeRoles{
+						fixtures.MessageBType: message.EventRole,
+						fixtures.MessageCType: message.TimeoutRole, // diff
+					},
+					Consumed: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+					},
+				},
+			),
+			Entry(
+				"consumed messages differ",
+				EntityMessageTypes{
+					Roles: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+						fixtures.MessageBType: message.EventRole,
+					},
+					Produced: message.TypeRoles{
+						fixtures.MessageBType: message.EventRole,
+					},
+					Consumed: message.TypeRoles{
+						fixtures.MessageAType: message.CommandRole,
+						fixtures.MessageCType: message.TimeoutRole, // diff
+					},
+				},
+			),
+		)
+	})
+})

--- a/entity_test.go
+++ b/entity_test.go
@@ -9,6 +9,107 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("type EntityMessageNames", func() {
+	Describe("func IsEqual()", func() {
+		It("returns true if the sets are equivalent", func() {
+			a := EntityMessageNames{
+				Roles: message.NameRoles{
+					fixtures.MessageATypeName: message.CommandRole,
+					fixtures.MessageBTypeName: message.EventRole,
+				},
+				Produced: message.NameRoles{
+					fixtures.MessageBTypeName: message.EventRole,
+				},
+				Consumed: message.NameRoles{
+					fixtures.MessageATypeName: message.CommandRole,
+				},
+			}
+
+			b := EntityMessageNames{
+				Roles: message.NameRoles{
+					fixtures.MessageATypeName: message.CommandRole,
+					fixtures.MessageBTypeName: message.EventRole,
+				},
+				Produced: message.NameRoles{
+					fixtures.MessageBTypeName: message.EventRole,
+				},
+				Consumed: message.NameRoles{
+					fixtures.MessageATypeName: message.CommandRole,
+				},
+			}
+
+			Expect(a.IsEqual(b)).To(BeTrue())
+		})
+
+		DescribeTable(
+			"returns false if the sets are not equivalent",
+			func(b EntityMessageNames) {
+				a := EntityMessageNames{
+					Roles: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+						fixtures.MessageBTypeName: message.EventRole,
+					},
+					Produced: message.NameRoles{
+						fixtures.MessageBTypeName: message.EventRole,
+					},
+					Consumed: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+					},
+				}
+				Expect(a.IsEqual(b)).To(BeFalse())
+			},
+			Entry(
+				"roles differ",
+				EntityMessageNames{
+					Roles: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+						fixtures.MessageBTypeName: message.EventRole,
+						fixtures.MessageCTypeName: message.TimeoutRole, // diff
+					},
+					Produced: message.NameRoles{
+						fixtures.MessageBTypeName: message.EventRole,
+					},
+					Consumed: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+					},
+				},
+			),
+			Entry(
+				"produced messages differ",
+				EntityMessageNames{
+					Roles: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+						fixtures.MessageBTypeName: message.EventRole,
+					},
+					Produced: message.NameRoles{
+						fixtures.MessageBTypeName: message.EventRole,
+						fixtures.MessageCTypeName: message.TimeoutRole, // diff
+					},
+					Consumed: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+					},
+				},
+			),
+			Entry(
+				"consumed messages differ",
+				EntityMessageNames{
+					Roles: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+						fixtures.MessageBTypeName: message.EventRole,
+					},
+					Produced: message.NameRoles{
+						fixtures.MessageBTypeName: message.EventRole,
+					},
+					Consumed: message.NameRoles{
+						fixtures.MessageATypeName: message.CommandRole,
+						fixtures.MessageCTypeName: message.TimeoutRole, // diff
+					},
+				},
+			),
+		)
+	})
+})
+
 var _ = Describe("type EntityMessageTypes", func() {
 	Describe("func IsEqual()", func() {
 		It("returns true if the sets are equivalent", func() {

--- a/message/nameroles.go
+++ b/message/nameroles.go
@@ -61,6 +61,22 @@ func (nr NameRoles) RemoveM(m dogma.Message) bool {
 	return nr.Remove(NameOf(m))
 }
 
+// IsEqual returns true if o contains the same names with the same roles as s.
+func (nr NameRoles) IsEqual(o NameRoles) bool {
+	if len(nr) != len(o) {
+		return false
+	}
+
+	for n, r := range nr {
+		x, ok := o[n]
+		if !ok || x != r {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Each invokes fn once for each name in the container.
 //
 // Iteration stops when fn returns false or once fn has been invoked for all

--- a/message/nameroles_test.go
+++ b/message/nameroles_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -165,6 +166,70 @@ var _ = Describe("type NameRoles", func() {
 				nr.RemoveM(MessageA1),
 			).To(BeFalse())
 		})
+	})
+
+	Describe("func IsEqual()", func() {
+		DescribeTable(
+			"returns true if the sets are equivalent",
+			func(a, b NameRoles) {
+				Expect(a.IsEqual(b)).To(BeTrue())
+			},
+			Entry(
+				"equivalent",
+				NameRoles{
+					MessageATypeName: CommandRole,
+					MessageBTypeName: EventRole,
+				},
+				NameRoles{
+					MessageATypeName: CommandRole,
+					MessageBTypeName: EventRole,
+				},
+			),
+			Entry(
+				"nil and empty",
+				NameRoles{},
+				NameRoles(nil),
+			),
+		)
+
+		DescribeTable(
+			"returns false if the sets are not equivalent",
+			func(b NameRoles) {
+				a := NameRoles{
+					MessageATypeName: CommandRole,
+					MessageBTypeName: EventRole,
+				}
+				Expect(a.IsEqual(b)).To(BeFalse())
+			},
+			Entry(
+				"subset",
+				NameRoles{
+					MessageATypeName: CommandRole,
+				},
+			),
+			Entry(
+				"superset",
+				NameRoles{
+					MessageATypeName: CommandRole,
+					MessageBTypeName: EventRole,
+					MessageCTypeName: TimeoutRole,
+				},
+			),
+			Entry(
+				"same-length, disjoint type",
+				NameRoles{
+					MessageATypeName: CommandRole,
+					MessageCTypeName: EventRole,
+				},
+			),
+			Entry(
+				"same-length, disjoint role",
+				NameRoles{
+					MessageATypeName: CommandRole,
+					MessageBTypeName: TimeoutRole,
+				},
+			),
+		)
 	})
 
 	Describe("func Each()", func() {

--- a/message/nameset.go
+++ b/message/nameset.go
@@ -83,6 +83,21 @@ func (s NameSet) RemoveM(m dogma.Message) bool {
 	return s.Remove(NameOf(m))
 }
 
+// IsEqual returns true if o contains the same names as s.
+func (s NameSet) IsEqual(o NameSet) bool {
+	if len(s) != len(o) {
+		return false
+	}
+
+	for t := range s {
+		if _, ok := o[t]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Each invokes fn once for each name in the container.
 //
 // Iteration stops when fn returns false or once fn has been invoked for all

--- a/message/nameset_test.go
+++ b/message/nameset_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -183,6 +184,48 @@ var _ = Describe("type NameSet", func() {
 				s.RemoveM(MessageA1),
 			).To(BeFalse())
 		})
+	})
+
+	Describe("func IsEqual()", func() {
+		DescribeTable(
+			"returns true if the sets are equivalent",
+			func(a, b NameSet) {
+				Expect(a.IsEqual(b)).To(BeTrue())
+			},
+			Entry(
+				"equivalent",
+				NewNameSet(MessageATypeName, MessageBTypeName),
+				NewNameSet(MessageATypeName, MessageBTypeName),
+			),
+			Entry(
+				"nil and empty",
+				NewNameSet(),
+				NameSet(nil),
+			),
+		)
+
+		DescribeTable(
+			"returns false if the sets are not equivalent",
+			func(b NameSet) {
+				a := NewNameSet(
+					MessageATypeName,
+					MessageBTypeName,
+				)
+				Expect(a.IsEqual(b)).To(BeFalse())
+			},
+			Entry(
+				"subset",
+				NewNameSet(MessageATypeName),
+			),
+			Entry(
+				"superset",
+				NewNameSet(MessageATypeName, MessageBTypeName, MessageCTypeName),
+			),
+			Entry(
+				"same-length, disjoint",
+				NewNameSet(MessageATypeName, MessageCTypeName),
+			),
+		)
 	})
 
 	Describe("func Each()", func() {

--- a/message/typeroles.go
+++ b/message/typeroles.go
@@ -61,7 +61,7 @@ func (tr TypeRoles) RemoveM(m dogma.Message) bool {
 	return tr.Remove(TypeOf(m))
 }
 
-// IsEqual returns true if o contains the same types with the same roles as s.
+// IsEqual returns true if o contains the same types with the same roles as tr.
 func (tr TypeRoles) IsEqual(o TypeRoles) bool {
 	if len(tr) != len(o) {
 		return false

--- a/message/typeroles.go
+++ b/message/typeroles.go
@@ -61,6 +61,22 @@ func (tr TypeRoles) RemoveM(m dogma.Message) bool {
 	return tr.Remove(TypeOf(m))
 }
 
+// IsEqual returns true if o contains the same types with the same roles as s.
+func (tr TypeRoles) IsEqual(o TypeRoles) bool {
+	if len(tr) != len(o) {
+		return false
+	}
+
+	for t, r := range tr {
+		x, ok := o[t]
+		if !ok || x != r {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Each invokes fn once for each type in the container.
 //
 // Iteration stops when fn returns false or once fn has been invoked for all

--- a/message/typeroles_test.go
+++ b/message/typeroles_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -165,6 +166,70 @@ var _ = Describe("type TypeRoles", func() {
 				tr.RemoveM(MessageA1),
 			).To(BeFalse())
 		})
+	})
+
+	Describe("func IsEqual()", func() {
+		DescribeTable(
+			"returns true if the sets are equivalent",
+			func(a, b TypeRoles) {
+				Expect(a.IsEqual(b)).To(BeTrue())
+			},
+			Entry(
+				"equivalent",
+				TypeRoles{
+					MessageAType: CommandRole,
+					MessageBType: EventRole,
+				},
+				TypeRoles{
+					MessageAType: CommandRole,
+					MessageBType: EventRole,
+				},
+			),
+			Entry(
+				"nil and empty",
+				TypeRoles{},
+				TypeRoles(nil),
+			),
+		)
+
+		DescribeTable(
+			"returns false if the sets are not equivalent",
+			func(b TypeRoles) {
+				a := TypeRoles{
+					MessageAType: CommandRole,
+					MessageBType: EventRole,
+				}
+				Expect(a.IsEqual(b)).To(BeFalse())
+			},
+			Entry(
+				"subset",
+				TypeRoles{
+					MessageAType: CommandRole,
+				},
+			),
+			Entry(
+				"superset",
+				TypeRoles{
+					MessageAType: CommandRole,
+					MessageBType: EventRole,
+					MessageCType: TimeoutRole,
+				},
+			),
+			Entry(
+				"same-length, disjoint type",
+				TypeRoles{
+					MessageAType: CommandRole,
+					MessageCType: EventRole,
+				},
+			),
+			Entry(
+				"same-length, disjoint role",
+				TypeRoles{
+					MessageAType: CommandRole,
+					MessageBType: TimeoutRole,
+				},
+			),
+		)
 	})
 
 	Describe("func Each()", func() {

--- a/message/typeset.go
+++ b/message/typeset.go
@@ -83,6 +83,21 @@ func (s TypeSet) RemoveM(m dogma.Message) bool {
 	return s.Remove(TypeOf(m))
 }
 
+// IsEqual returns true if o contains the same types as s.
+func (s TypeSet) IsEqual(o TypeSet) bool {
+	if len(s) != len(o) {
+		return false
+	}
+
+	for t := range s {
+		if _, ok := o[t]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Each invokes fn once for each type in the container.
 //
 // Iteration stops when fn returns false or once fn has been invoked for all

--- a/message/typeset_test.go
+++ b/message/typeset_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -183,6 +184,48 @@ var _ = Describe("type TypeSet", func() {
 				s.RemoveM(MessageA1),
 			).To(BeFalse())
 		})
+	})
+
+	Describe("func IsEqual()", func() {
+		DescribeTable(
+			"returns true if the sets are equivalent",
+			func(a, b TypeSet) {
+				Expect(a.IsEqual(b)).To(BeTrue())
+			},
+			Entry(
+				"equivalent",
+				NewTypeSet(MessageAType, MessageBType),
+				NewTypeSet(MessageAType, MessageBType),
+			),
+			Entry(
+				"nil and empty",
+				NewTypeSet(),
+				TypeSet(nil),
+			),
+		)
+
+		DescribeTable(
+			"returns false if the sets are not equivalent",
+			func(b TypeSet) {
+				a := NewTypeSet(
+					MessageAType,
+					MessageBType,
+				)
+				Expect(a.IsEqual(b)).To(BeFalse())
+			},
+			Entry(
+				"subset",
+				NewTypeSet(MessageAType),
+			),
+			Entry(
+				"superset",
+				NewTypeSet(MessageAType, MessageBType, MessageCType),
+			),
+			Entry(
+				"same-length, disjoint",
+				NewTypeSet(MessageAType, MessageCType),
+			),
+		)
 	})
 
 	Describe("func Each()", func() {


### PR DESCRIPTION
Partially addresses #27.

This PR adds `IsEqual()` methods to most of the concrete types listed in #27. Specifically, it does not include any `IsEqual()` implementations that would depend on comparing the entities (application/handler configs). I will address those in a separate PR.

- [x] `message.NameRoles`
- [x] `message.NameSet`
- [x] `message.TypeRoles`
- [x] `message.TypeSet`
- [x] `EntityMessageNames`
- [x] `EntityMessageTypes`
