### PR TITLE
Replace `EntityMessage[Names|Types].Roles` with `All()` method.

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -48,11 +48,6 @@ var _ = Describe("func FromAggregate()", func() {
 			It("returns the expected message names", func() {
 				Expect(cfg.MessageNames()).To(Equal(
 					EntityMessageNames{
-						Roles: message.NameRoles{
-							cfixtures.MessageATypeName: message.CommandRole,
-							cfixtures.MessageBTypeName: message.CommandRole,
-							cfixtures.MessageETypeName: message.EventRole,
-						},
 						Produced: message.NameRoles{
 							cfixtures.MessageETypeName: message.EventRole,
 						},
@@ -69,11 +64,6 @@ var _ = Describe("func FromAggregate()", func() {
 			It("returns the expected message types", func() {
 				Expect(cfg.MessageTypes()).To(Equal(
 					EntityMessageTypes{
-						Roles: message.TypeRoles{
-							cfixtures.MessageAType: message.CommandRole,
-							cfixtures.MessageBType: message.CommandRole,
-							cfixtures.MessageEType: message.EventRole,
-						},
 						Produced: message.TypeRoles{
 							cfixtures.MessageEType: message.EventRole,
 						},

--- a/application.go
+++ b/application.go
@@ -87,7 +87,6 @@ func IsApplicationEqual(a, b Application) bool {
 func ForeignMessageNames(app Application) EntityMessageNames {
 	m := app.MessageNames()
 	f := EntityMessageNames{
-		Roles:    message.NameRoles{},
 		Produced: message.NameRoles{},
 		Consumed: message.NameRoles{},
 	}
@@ -97,7 +96,6 @@ func ForeignMessageNames(app Application) EntityMessageNames {
 		// produced by this application, but not consumed by this application is
 		// considered foreign.
 		if r == message.CommandRole && !m.Consumed.Has(n) {
-			f.Roles.Add(n, r)
 			f.Produced.Add(n, r)
 		}
 	}
@@ -106,7 +104,6 @@ func ForeignMessageNames(app Application) EntityMessageNames {
 		// Any message, of any role, that is consumed by this application but
 		// not produced by this application is considered foreign.
 		if !m.Produced.Has(n) {
-			f.Roles.Add(n, r)
 			f.Consumed.Add(n, r)
 		}
 	}
@@ -124,7 +121,6 @@ func ForeignMessageNames(app Application) EntityMessageNames {
 func ForeignMessageTypes(app RichApplication) EntityMessageTypes {
 	m := app.MessageTypes()
 	f := EntityMessageTypes{
-		Roles:    message.TypeRoles{},
 		Produced: message.TypeRoles{},
 		Consumed: message.TypeRoles{},
 	}
@@ -134,7 +130,6 @@ func ForeignMessageTypes(app RichApplication) EntityMessageTypes {
 		// produced by this application, but not consumed by this application is
 		// considered foreign.
 		if r == message.CommandRole && !m.Consumed.Has(t) {
-			f.Roles.Add(t, r)
 			f.Produced.Add(t, r)
 		}
 	}
@@ -143,7 +138,6 @@ func ForeignMessageTypes(app RichApplication) EntityMessageTypes {
 		// Any message, of any role, that is consumed by this application but
 		// not produced by this application is considered foreign.
 		if !m.Produced.Has(t) {
-			f.Roles.Add(t, r)
 			f.Consumed.Add(t, r)
 		}
 	}

--- a/application_test.go
+++ b/application_test.go
@@ -89,15 +89,6 @@ var _ = Describe("func FromApplication()", func() {
 			It("returns the expected message names", func() {
 				Expect(cfg.MessageNames()).To(Equal(
 					EntityMessageNames{
-						Roles: message.NameRoles{
-							cfixtures.MessageATypeName: message.CommandRole,
-							cfixtures.MessageBTypeName: message.EventRole,
-							cfixtures.MessageCTypeName: message.CommandRole,
-							cfixtures.MessageDTypeName: message.EventRole,
-							cfixtures.MessageETypeName: message.EventRole,
-							cfixtures.MessageFTypeName: message.EventRole,
-							cfixtures.MessageTTypeName: message.TimeoutRole,
-						},
 						Produced: message.NameRoles{
 							cfixtures.MessageCTypeName: message.CommandRole,
 							cfixtures.MessageETypeName: message.EventRole,
@@ -121,15 +112,6 @@ var _ = Describe("func FromApplication()", func() {
 			It("returns the expected message types", func() {
 				Expect(cfg.MessageTypes()).To(Equal(
 					EntityMessageTypes{
-						Roles: message.TypeRoles{
-							cfixtures.MessageAType: message.CommandRole,
-							cfixtures.MessageBType: message.EventRole,
-							cfixtures.MessageCType: message.CommandRole,
-							cfixtures.MessageDType: message.EventRole,
-							cfixtures.MessageEType: message.EventRole,
-							cfixtures.MessageFType: message.EventRole,
-							cfixtures.MessageTType: message.TimeoutRole,
-						},
 						Produced: message.TypeRoles{
 							cfixtures.MessageCType: message.CommandRole,
 							cfixtures.MessageEType: message.EventRole,
@@ -608,11 +590,6 @@ var _ = Context("foreign messages", func() {
 		It("returns the set of messages that belong to another application", func() {
 			Expect(ForeignMessageNames(cfg)).To(Equal(
 				EntityMessageNames{
-					Roles: message.NameRoles{
-						cfixtures.MessageCTypeName: message.CommandRole,
-						cfixtures.MessageFTypeName: message.EventRole,
-						cfixtures.MessageDTypeName: message.CommandRole,
-					},
 					Produced: message.NameRoles{
 						cfixtures.MessageDTypeName: message.CommandRole,
 					},
@@ -629,11 +606,6 @@ var _ = Context("foreign messages", func() {
 		It("returns the set of messages that belong to another application", func() {
 			Expect(ForeignMessageTypes(cfg)).To(Equal(
 				EntityMessageTypes{
-					Roles: message.TypeRoles{
-						cfixtures.MessageCType: message.CommandRole,
-						cfixtures.MessageFType: message.EventRole,
-						cfixtures.MessageDType: message.CommandRole,
-					},
 					Produced: message.TypeRoles{
 						cfixtures.MessageDType: message.CommandRole,
 					},

--- a/entity.go
+++ b/entity.go
@@ -46,9 +46,6 @@ type RichEntity interface {
 // EntityMessageNames describes how messages are used within a Dogma entity
 // where each message is identified by its name.
 type EntityMessageNames struct {
-	// Roles is a map of message name to its role within the entity.
-	Roles message.NameRoles
-
 	// Produced is a set of message names produced by the entity.
 	Produced message.NameRoles
 
@@ -56,19 +53,40 @@ type EntityMessageNames struct {
 	Consumed message.NameRoles
 }
 
+// RoleOf returns the role associated with n, if any.
+func (m EntityMessageNames) RoleOf(n message.Name) (message.Role, bool) {
+	if r, ok := m.Produced[n]; ok {
+		return r, true
+	}
+
+	r, ok := m.Consumed[n]
+	return r, ok
+}
+
+// All returns the type roles of all messages, both produced and consumed.
+func (m EntityMessageNames) All() message.NameRoles {
+	roles := message.NameRoles{}
+
+	for n, r := range m.Produced {
+		roles[n] = r
+	}
+
+	for n, r := range m.Consumed {
+		roles[n] = r
+	}
+
+	return roles
+}
+
 // IsEqual returns true if m is equal to o.
 func (m EntityMessageNames) IsEqual(o EntityMessageNames) bool {
-	return m.Roles.IsEqual(o.Roles) &&
-		m.Produced.IsEqual(o.Produced) &&
+	return m.Produced.IsEqual(o.Produced) &&
 		m.Consumed.IsEqual(o.Consumed)
 }
 
 // EntityMessageTypes describes how messages are used within a Dogma entity
 // where each message is identified by its type.
 type EntityMessageTypes struct {
-	// Roles is a map of message type to its role within the entity.
-	Roles message.TypeRoles
-
 	// Produced is a set of message types produced by the entity.
 	Produced message.TypeRoles
 
@@ -76,10 +94,34 @@ type EntityMessageTypes struct {
 	Consumed message.TypeRoles
 }
 
+// RoleOf returns the role associated with t, if any.
+func (m EntityMessageTypes) RoleOf(t message.Type) (message.Role, bool) {
+	if r, ok := m.Produced[t]; ok {
+		return r, true
+	}
+
+	r, ok := m.Consumed[t]
+	return r, ok
+}
+
+// All returns the type roles of all messages, both produced and consumed.
+func (m EntityMessageTypes) All() message.TypeRoles {
+	roles := message.TypeRoles{}
+
+	for t, r := range m.Produced {
+		roles[t] = r
+	}
+
+	for t, r := range m.Consumed {
+		roles[t] = r
+	}
+
+	return roles
+}
+
 // IsEqual returns true if m is equal to o.
 func (m EntityMessageTypes) IsEqual(o EntityMessageTypes) bool {
-	return m.Roles.IsEqual(o.Roles) &&
-		m.Produced.IsEqual(o.Produced) &&
+	return m.Produced.IsEqual(o.Produced) &&
 		m.Consumed.IsEqual(o.Consumed)
 }
 

--- a/entity_test.go
+++ b/entity_test.go
@@ -35,7 +35,7 @@ var _ = Describe("type EntityMessageNames", func() {
 			Expect(r).To(Equal(message.CommandRole))
 		})
 
-		It("returns false if the message is neither produced or consumed", func() {
+		It("returns false if the message is neither produced nor consumed", func() {
 			m := EntityMessageNames{}
 
 			_, ok := m.RoleOf(fixtures.MessageATypeName)
@@ -153,7 +153,7 @@ var _ = Describe("type EntityMessageTypes", func() {
 			Expect(r).To(Equal(message.CommandRole))
 		})
 
-		It("returns false if the message is neither produced or consumed", func() {
+		It("returns false if the message is neither produced nor consumed", func() {
 			m := EntityMessageTypes{}
 
 			_, ok := m.RoleOf(fixtures.MessageAType)

--- a/entity_test.go
+++ b/entity_test.go
@@ -10,13 +10,62 @@ import (
 )
 
 var _ = Describe("type EntityMessageNames", func() {
+	Describe("func RoleOf()", func() {
+		It("returns the role of a produced message", func() {
+			m := EntityMessageNames{
+				Produced: message.NameRoles{
+					fixtures.MessageATypeName: message.CommandRole,
+				},
+			}
+
+			r, ok := m.RoleOf(fixtures.MessageATypeName)
+			Expect(ok).To(BeTrue())
+			Expect(r).To(Equal(message.CommandRole))
+		})
+
+		It("returns the role of a consumed message", func() {
+			m := EntityMessageNames{
+				Consumed: message.NameRoles{
+					fixtures.MessageATypeName: message.CommandRole,
+				},
+			}
+
+			r, ok := m.RoleOf(fixtures.MessageATypeName)
+			Expect(ok).To(BeTrue())
+			Expect(r).To(Equal(message.CommandRole))
+		})
+
+		It("returns false is the message is neither produced or consumed", func() {
+			m := EntityMessageNames{}
+
+			_, ok := m.RoleOf(fixtures.MessageATypeName)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("func All()", func() {
+		It("returns the union of the produced and consumed messages", func() {
+			m := EntityMessageNames{
+				Produced: message.NameRoles{
+					fixtures.MessageCTypeName: message.CommandRole,
+				},
+				Consumed: message.NameRoles{
+					fixtures.MessageETypeName: message.EventRole,
+				},
+			}
+
+			Expect(m.All()).To(Equal(
+				message.NameRoles{
+					fixtures.MessageCTypeName: message.CommandRole,
+					fixtures.MessageETypeName: message.EventRole,
+				},
+			))
+		})
+	})
+
 	Describe("func IsEqual()", func() {
 		It("returns true if the sets are equivalent", func() {
 			a := EntityMessageNames{
-				Roles: message.NameRoles{
-					fixtures.MessageATypeName: message.CommandRole,
-					fixtures.MessageBTypeName: message.EventRole,
-				},
 				Produced: message.NameRoles{
 					fixtures.MessageBTypeName: message.EventRole,
 				},
@@ -26,10 +75,6 @@ var _ = Describe("type EntityMessageNames", func() {
 			}
 
 			b := EntityMessageNames{
-				Roles: message.NameRoles{
-					fixtures.MessageATypeName: message.CommandRole,
-					fixtures.MessageBTypeName: message.EventRole,
-				},
 				Produced: message.NameRoles{
 					fixtures.MessageBTypeName: message.EventRole,
 				},
@@ -45,10 +90,6 @@ var _ = Describe("type EntityMessageNames", func() {
 			"returns false if the sets are not equivalent",
 			func(b EntityMessageNames) {
 				a := EntityMessageNames{
-					Roles: message.NameRoles{
-						fixtures.MessageATypeName: message.CommandRole,
-						fixtures.MessageBTypeName: message.EventRole,
-					},
 					Produced: message.NameRoles{
 						fixtures.MessageBTypeName: message.EventRole,
 					},
@@ -59,28 +100,8 @@ var _ = Describe("type EntityMessageNames", func() {
 				Expect(a.IsEqual(b)).To(BeFalse())
 			},
 			Entry(
-				"roles differ",
-				EntityMessageNames{
-					Roles: message.NameRoles{
-						fixtures.MessageATypeName: message.CommandRole,
-						fixtures.MessageBTypeName: message.EventRole,
-						fixtures.MessageCTypeName: message.TimeoutRole, // diff
-					},
-					Produced: message.NameRoles{
-						fixtures.MessageBTypeName: message.EventRole,
-					},
-					Consumed: message.NameRoles{
-						fixtures.MessageATypeName: message.CommandRole,
-					},
-				},
-			),
-			Entry(
 				"produced messages differ",
 				EntityMessageNames{
-					Roles: message.NameRoles{
-						fixtures.MessageATypeName: message.CommandRole,
-						fixtures.MessageBTypeName: message.EventRole,
-					},
 					Produced: message.NameRoles{
 						fixtures.MessageBTypeName: message.EventRole,
 						fixtures.MessageCTypeName: message.TimeoutRole, // diff
@@ -93,10 +114,6 @@ var _ = Describe("type EntityMessageNames", func() {
 			Entry(
 				"consumed messages differ",
 				EntityMessageNames{
-					Roles: message.NameRoles{
-						fixtures.MessageATypeName: message.CommandRole,
-						fixtures.MessageBTypeName: message.EventRole,
-					},
 					Produced: message.NameRoles{
 						fixtures.MessageBTypeName: message.EventRole,
 					},
@@ -111,13 +128,62 @@ var _ = Describe("type EntityMessageNames", func() {
 })
 
 var _ = Describe("type EntityMessageTypes", func() {
+	Describe("func RoleOf()", func() {
+		It("returns the role of a produced message", func() {
+			m := EntityMessageTypes{
+				Produced: message.TypeRoles{
+					fixtures.MessageAType: message.CommandRole,
+				},
+			}
+
+			r, ok := m.RoleOf(fixtures.MessageAType)
+			Expect(ok).To(BeTrue())
+			Expect(r).To(Equal(message.CommandRole))
+		})
+
+		It("returns the role of a consumed message", func() {
+			m := EntityMessageTypes{
+				Consumed: message.TypeRoles{
+					fixtures.MessageAType: message.CommandRole,
+				},
+			}
+
+			r, ok := m.RoleOf(fixtures.MessageAType)
+			Expect(ok).To(BeTrue())
+			Expect(r).To(Equal(message.CommandRole))
+		})
+
+		It("returns false is the message is neither produced or consumed", func() {
+			m := EntityMessageTypes{}
+
+			_, ok := m.RoleOf(fixtures.MessageAType)
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("func All()", func() {
+		It("returns the union of the produced and consumed messages", func() {
+			m := EntityMessageTypes{
+				Produced: message.TypeRoles{
+					fixtures.MessageCType: message.CommandRole,
+				},
+				Consumed: message.TypeRoles{
+					fixtures.MessageEType: message.EventRole,
+				},
+			}
+
+			Expect(m.All()).To(Equal(
+				message.TypeRoles{
+					fixtures.MessageCType: message.CommandRole,
+					fixtures.MessageEType: message.EventRole,
+				},
+			))
+		})
+	})
+
 	Describe("func IsEqual()", func() {
 		It("returns true if the sets are equivalent", func() {
 			a := EntityMessageTypes{
-				Roles: message.TypeRoles{
-					fixtures.MessageAType: message.CommandRole,
-					fixtures.MessageBType: message.EventRole,
-				},
 				Produced: message.TypeRoles{
 					fixtures.MessageBType: message.EventRole,
 				},
@@ -127,10 +193,6 @@ var _ = Describe("type EntityMessageTypes", func() {
 			}
 
 			b := EntityMessageTypes{
-				Roles: message.TypeRoles{
-					fixtures.MessageAType: message.CommandRole,
-					fixtures.MessageBType: message.EventRole,
-				},
 				Produced: message.TypeRoles{
 					fixtures.MessageBType: message.EventRole,
 				},
@@ -146,10 +208,6 @@ var _ = Describe("type EntityMessageTypes", func() {
 			"returns false if the sets are not equivalent",
 			func(b EntityMessageTypes) {
 				a := EntityMessageTypes{
-					Roles: message.TypeRoles{
-						fixtures.MessageAType: message.CommandRole,
-						fixtures.MessageBType: message.EventRole,
-					},
 					Produced: message.TypeRoles{
 						fixtures.MessageBType: message.EventRole,
 					},
@@ -160,28 +218,8 @@ var _ = Describe("type EntityMessageTypes", func() {
 				Expect(a.IsEqual(b)).To(BeFalse())
 			},
 			Entry(
-				"roles differ",
-				EntityMessageTypes{
-					Roles: message.TypeRoles{
-						fixtures.MessageAType: message.CommandRole,
-						fixtures.MessageBType: message.EventRole,
-						fixtures.MessageCType: message.TimeoutRole, // diff
-					},
-					Produced: message.TypeRoles{
-						fixtures.MessageBType: message.EventRole,
-					},
-					Consumed: message.TypeRoles{
-						fixtures.MessageAType: message.CommandRole,
-					},
-				},
-			),
-			Entry(
 				"produced messages differ",
 				EntityMessageTypes{
-					Roles: message.TypeRoles{
-						fixtures.MessageAType: message.CommandRole,
-						fixtures.MessageBType: message.EventRole,
-					},
 					Produced: message.TypeRoles{
 						fixtures.MessageBType: message.EventRole,
 						fixtures.MessageCType: message.TimeoutRole, // diff
@@ -194,10 +232,6 @@ var _ = Describe("type EntityMessageTypes", func() {
 			Entry(
 				"consumed messages differ",
 				EntityMessageTypes{
-					Roles: message.TypeRoles{
-						fixtures.MessageAType: message.CommandRole,
-						fixtures.MessageBType: message.EventRole,
-					},
 					Produced: message.TypeRoles{
 						fixtures.MessageBType: message.EventRole,
 					},

--- a/entity_test.go
+++ b/entity_test.go
@@ -35,7 +35,7 @@ var _ = Describe("type EntityMessageNames", func() {
 			Expect(r).To(Equal(message.CommandRole))
 		})
 
-		It("returns false is the message is neither produced or consumed", func() {
+		It("returns false if the message is neither produced or consumed", func() {
 			m := EntityMessageNames{}
 
 			_, ok := m.RoleOf(fixtures.MessageATypeName)
@@ -153,7 +153,7 @@ var _ = Describe("type EntityMessageTypes", func() {
 			Expect(r).To(Equal(message.CommandRole))
 		})
 
-		It("returns false is the message is neither produced or consumed", func() {
+		It("returns false if the message is neither produced or consumed", func() {
 			m := EntityMessageTypes{}
 
 			_, ok := m.RoleOf(fixtures.MessageAType)

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -65,20 +65,13 @@ func (c *handlerConfigurer) consumes(m dogma.Message, r message.Role, verb strin
 		)
 	}
 
-	if c.entity.names.Roles == nil {
-		c.entity.names.Roles = message.NameRoles{}
-		c.entity.types.Roles = message.TypeRoles{}
-	}
-
 	if c.entity.names.Consumed == nil {
 		c.entity.names.Consumed = message.NameRoles{}
 		c.entity.types.Consumed = message.TypeRoles{}
 	}
 
 	n := mt.Name()
-	c.entity.names.Roles.Add(n, r)
 	c.entity.names.Consumed.Add(n, r)
-	c.entity.types.Roles.Add(mt, r)
 	c.entity.types.Consumed.Add(mt, r)
 }
 
@@ -96,10 +89,6 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 			r,
 		)
 	}
-	if c.entity.names.Roles == nil {
-		c.entity.names.Roles = message.NameRoles{}
-		c.entity.types.Roles = message.TypeRoles{}
-	}
 
 	if c.entity.names.Produced == nil {
 		c.entity.names.Produced = message.NameRoles{}
@@ -107,15 +96,13 @@ func (c *handlerConfigurer) produces(m dogma.Message, r message.Role, verb strin
 	}
 
 	n := mt.Name()
-	c.entity.names.Roles.Add(n, r)
 	c.entity.names.Produced.Add(n, r)
-	c.entity.types.Roles.Add(mt, r)
 	c.entity.types.Produced.Add(mt, r)
 }
 
 // guardAgainstConflictingRoles panics if mt is already used in some role other than r.
 func (c *handlerConfigurer) guardAgainstConflictingRoles(mt message.Type, r message.Role) {
-	x, ok := c.entity.types.Roles[mt]
+	x, ok := c.entity.types.RoleOf(mt)
 
 	if !ok || x == r {
 		return
@@ -133,8 +120,10 @@ func (c *handlerConfigurer) guardAgainstConflictingRoles(mt message.Type, r mess
 // mustConsume panics if the handler does not consume any messages of the given role.
 func (c *handlerConfigurer) mustConsume(r message.Role) {
 	for mt := range c.entity.names.Consumed {
-		if r == c.entity.names.Roles[mt] {
-			return
+		if x, ok := c.entity.names.RoleOf(mt); ok {
+			if x == r {
+				return
+			}
 		}
 	}
 
@@ -150,8 +139,10 @@ func (c *handlerConfigurer) mustConsume(r message.Role) {
 // mustProduce panics if the handler does not produce any messages of the given role.
 func (c *handlerConfigurer) mustProduce(r message.Role) {
 	for mt := range c.entity.names.Produced {
-		if r == c.entity.names.Roles[mt] {
-			return
+		if x, ok := c.entity.names.RoleOf(mt); ok {
+			if x == r {
+				return
+			}
 		}
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -48,11 +48,6 @@ var _ = Describe("func FromIntegration()", func() {
 			It("returns the expected message names", func() {
 				Expect(cfg.MessageNames()).To(Equal(
 					EntityMessageNames{
-						Roles: message.NameRoles{
-							cfixtures.MessageATypeName: message.CommandRole,
-							cfixtures.MessageBTypeName: message.CommandRole,
-							cfixtures.MessageETypeName: message.EventRole,
-						},
 						Produced: message.NameRoles{
 							cfixtures.MessageETypeName: message.EventRole,
 						},
@@ -69,11 +64,6 @@ var _ = Describe("func FromIntegration()", func() {
 			It("returns the expected message types", func() {
 				Expect(cfg.MessageTypes()).To(Equal(
 					EntityMessageTypes{
-						Roles: message.TypeRoles{
-							cfixtures.MessageAType: message.CommandRole,
-							cfixtures.MessageBType: message.CommandRole,
-							cfixtures.MessageEType: message.EventRole,
-						},
 						Produced: message.TypeRoles{
 							cfixtures.MessageEType: message.EventRole,
 						},

--- a/process_test.go
+++ b/process_test.go
@@ -49,12 +49,6 @@ var _ = Describe("func FromProcess()", func() {
 			It("returns the expected message names", func() {
 				Expect(cfg.MessageNames()).To(Equal(
 					EntityMessageNames{
-						Roles: message.NameRoles{
-							cfixtures.MessageATypeName: message.EventRole,
-							cfixtures.MessageBTypeName: message.EventRole,
-							cfixtures.MessageCTypeName: message.CommandRole,
-							cfixtures.MessageTTypeName: message.TimeoutRole,
-						},
 						Produced: message.NameRoles{
 							cfixtures.MessageCTypeName: message.CommandRole,
 							cfixtures.MessageTTypeName: message.TimeoutRole,
@@ -73,12 +67,6 @@ var _ = Describe("func FromProcess()", func() {
 			It("returns the expected message types", func() {
 				Expect(cfg.MessageTypes()).To(Equal(
 					EntityMessageTypes{
-						Roles: message.TypeRoles{
-							cfixtures.MessageAType: message.EventRole,
-							cfixtures.MessageBType: message.EventRole,
-							cfixtures.MessageCType: message.CommandRole,
-							cfixtures.MessageTType: message.TimeoutRole,
-						},
 						Produced: message.TypeRoles{
 							cfixtures.MessageCType: message.CommandRole,
 							cfixtures.MessageTType: message.TimeoutRole,

--- a/projection_test.go
+++ b/projection_test.go
@@ -47,10 +47,6 @@ var _ = Describe("func FromProjection()", func() {
 			It("returns the expected message names", func() {
 				Expect(cfg.MessageNames()).To(Equal(
 					EntityMessageNames{
-						Roles: message.NameRoles{
-							cfixtures.MessageATypeName: message.EventRole,
-							cfixtures.MessageBTypeName: message.EventRole,
-						},
 						Produced: nil,
 						Consumed: message.NameRoles{
 							cfixtures.MessageATypeName: message.EventRole,
@@ -65,10 +61,6 @@ var _ = Describe("func FromProjection()", func() {
 			It("returns the expected message types", func() {
 				Expect(cfg.MessageTypes()).To(Equal(
 					EntityMessageTypes{
-						Roles: message.TypeRoles{
-							cfixtures.MessageAType: message.EventRole,
-							cfixtures.MessageBType: message.EventRole,
-						},
 						Produced: nil,
 						Consumed: message.TypeRoles{
 							cfixtures.MessageAType: message.EventRole,


### PR DESCRIPTION
Rather than requiring the implementations to populate the `Roles` collection with the union of `Produced` and `Consumed` it is now computed on the fly.

I've also added a `RoleOf()` method to efficiently obtain the role of a message without having to first compute the union.