### PR TITLE
Add `ToString()`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/dogmatiq/dogma v0.6.2
+	github.com/dogmatiq/iago v0.4.0
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/dogmatiq/dogma v0.6.2 h1:srGSGAu8ZpQ+c23EUVq35mDn47HZbbLr5Q9PhGRH7NE=
 github.com/dogmatiq/dogma v0.6.2/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF5HGx0g=
+github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
+github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -7,8 +9,10 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
@@ -25,5 +29,6 @@ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/string.go
+++ b/string.go
@@ -1,0 +1,150 @@
+package configkit
+
+import (
+	"context"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/iago/indent"
+	"github.com/dogmatiq/iago/must"
+)
+
+// ToString returns a human-readable string representation of the given entity.
+func ToString(e Entity) string {
+	var b strings.Builder
+	e.AcceptVisitor(nil, &stringer{w: &b})
+	return b.String()
+}
+
+// stringer is a Visitor that builds string representations of entities.
+type stringer struct {
+	w io.Writer
+}
+
+func (s *stringer) VisitApplication(ctx context.Context, cfg Application) error {
+	id := cfg.Identity()
+
+	must.Fprintf(
+		s.w,
+		"application %s (%s) %s\n",
+		id.Name,
+		id.Key,
+		cfg.TypeName(),
+	)
+
+	v := &stringer{
+		w: indent.NewIndenter(s.w, nil),
+	}
+
+	for _, h := range sortHandlers(cfg.Handlers()) {
+		must.WriteByte(s.w, '\n')
+		must.WriteString(v.w, "- ")
+		h.AcceptVisitor(ctx, v)
+	}
+
+	return nil
+}
+
+func (s *stringer) visitHandler(cfg Handler) error {
+	id := cfg.Identity()
+
+	must.Fprintf(
+		s.w,
+		"%s %s (%s) %s\n",
+		cfg.HandlerType(),
+		id.Name,
+		id.Key,
+		cfg.TypeName(),
+	)
+
+	for _, p := range sortNameRoles(cfg.MessageNames().Consumed) {
+		if p.Role == message.TimeoutRole {
+			break
+		}
+
+		must.Fprintf(
+			s.w,
+			"    consumes %s%s\n",
+			p.Name,
+			p.Role.Marker(),
+		)
+	}
+
+	for _, p := range sortNameRoles(cfg.MessageNames().Produced) {
+		verb := "produces"
+		if p.Role == message.TimeoutRole {
+			verb = "schedules"
+		}
+
+		must.Fprintf(
+			s.w,
+			"    %s %s%s\n",
+			verb,
+			p.Name,
+			p.Role.Marker(),
+		)
+	}
+
+	return nil
+}
+
+func (s *stringer) VisitAggregate(_ context.Context, cfg Aggregate) error {
+	return s.visitHandler(cfg)
+}
+
+func (s *stringer) VisitProcess(_ context.Context, cfg Process) error {
+	return s.visitHandler(cfg)
+}
+
+func (s *stringer) VisitIntegration(_ context.Context, cfg Integration) error {
+	return s.visitHandler(cfg)
+}
+
+func (s *stringer) VisitProjection(_ context.Context, cfg Projection) error {
+	return s.visitHandler(cfg)
+}
+
+// sortHandlers returns a set of handlers sorted by their name.
+func sortHandlers(handlers HandlerSet) []Handler {
+	sorted := make([]Handler, 0, len(handlers))
+
+	for _, h := range handlers {
+		sorted = append(sorted, h)
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Identity().Name < sorted[j].Identity().Name
+	})
+
+	return sorted
+}
+
+type pair struct {
+	Name message.Name
+	Role message.Role
+}
+
+// sortNameRoles returns a list of name/role pairs, sorted by name.
+// Timeout messages are always sorted towards the end.
+func sortNameRoles(names message.NameRoles) []pair {
+	sorted := make([]pair, 0, len(names))
+
+	for n, r := range names {
+		sorted = append(sorted, pair{n, r})
+	}
+
+	sort.Slice(sorted, func(i, j int) bool {
+		pi := sorted[i]
+		pj := sorted[j]
+
+		if pi.Role == message.TimeoutRole && pj.Role != message.TimeoutRole {
+			return false
+		}
+
+		return pi.Name.String() < pj.Name.String()
+	})
+
+	return sorted
+}

--- a/string_test.go
+++ b/string_test.go
@@ -3,7 +3,7 @@ package configkit_test
 import (
 	"strings"
 
-	. "github.com/dogmatiq/configkit" // can't dot-import due to conflicts
+	. "github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
 	. "github.com/onsi/ginkgo"

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,89 @@
+package configkit_test
+
+import (
+	"strings"
+
+	. "github.com/dogmatiq/configkit" // can't dot-import due to conflicts
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func ToString()", func() {
+	var cfg Application
+
+	BeforeEach(func() {
+		app := &fixtures.Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+
+				c.RegisterAggregate(&fixtures.AggregateMessageHandler{
+					ConfigureFunc: func(c dogma.AggregateConfigurer) {
+						c.Identity("<aggregate>", "<aggregate-key>")
+						c.ConsumesCommandType(fixtures.MessageC{})
+						c.ProducesEventType(fixtures.MessageE{})
+					},
+				})
+
+				c.RegisterProcess(&fixtures.ProcessMessageHandler{
+					ConfigureFunc: func(c dogma.ProcessConfigurer) {
+						c.Identity("<process>", "<process-key>")
+						c.ConsumesEventType(fixtures.MessageE{})
+						c.ProducesCommandType(fixtures.MessageC{})
+						c.SchedulesTimeoutType(fixtures.MessageT{})
+					},
+				})
+
+				c.RegisterIntegration(&fixtures.IntegrationMessageHandler{
+					ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+						c.Identity("<integration>", "<integration-key>")
+						c.ConsumesCommandType(fixtures.MessageI{})
+						c.ProducesEventType(fixtures.MessageJ{})
+					},
+				})
+
+				c.RegisterProjection(&fixtures.ProjectionMessageHandler{
+					ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+						c.Identity("<projection>", "<projection-key>")
+						c.ConsumesEventType(fixtures.MessageE{})
+						c.ConsumesEventType(fixtures.MessageJ{})
+					},
+				})
+			},
+		}
+
+		cfg = FromApplication(app)
+	})
+
+	It("returns a human readable string representation", func() {
+		expected := "application <app> (<app-key>) *github.com/dogmatiq/dogma/fixtures.Application\n"
+		expected += "\n"
+		expected += "    - aggregate <aggregate> (<aggregate-key>) *github.com/dogmatiq/dogma/fixtures.AggregateMessageHandler\n"
+		expected += "        consumes github.com/dogmatiq/dogma/fixtures.MessageC?\n"
+		expected += "        produces github.com/dogmatiq/dogma/fixtures.MessageE!\n"
+		expected += "\n"
+		expected += "    - integration <integration> (<integration-key>) *github.com/dogmatiq/dogma/fixtures.IntegrationMessageHandler\n"
+		expected += "        consumes github.com/dogmatiq/dogma/fixtures.MessageI?\n"
+		expected += "        produces github.com/dogmatiq/dogma/fixtures.MessageJ!\n"
+		expected += "\n"
+		expected += "    - process <process> (<process-key>) *github.com/dogmatiq/dogma/fixtures.ProcessMessageHandler\n"
+		expected += "        consumes github.com/dogmatiq/dogma/fixtures.MessageE!\n"
+		expected += "        produces github.com/dogmatiq/dogma/fixtures.MessageC?\n"
+		expected += "        schedules github.com/dogmatiq/dogma/fixtures.MessageT@\n"
+		expected += "\n"
+		expected += "    - projection <projection> (<projection-key>) *github.com/dogmatiq/dogma/fixtures.ProjectionMessageHandler\n"
+		expected += "        consumes github.com/dogmatiq/dogma/fixtures.MessageE!\n"
+		expected += "        consumes github.com/dogmatiq/dogma/fixtures.MessageJ!\n"
+
+		s := ToString(cfg)
+
+		// compare as slices, as the failure output for slices is better than
+		// for multiline strings :(
+		Expect(
+			strings.Split(s, "\n"),
+		).To(
+			Equal(strings.Split(expected, "\n")),
+		)
+	})
+})


### PR DESCRIPTION
Fixes #32.

This function builds a simple, human-readable string describing an application or handler. The intent is mostly for debugging - allowing the developer to quickly dump out a representation of the application without having to reach for a more substantial tool such as graphkit.