### PR TITLE
Add set operations for `NameSet` and `TypeSet`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `message.IsIntersectingN()` and `IsSubsetN()`
+- Add `message.IntersectionN()` and `UnionN()` and `DiffN()`
+
 ## [0.2.1] - 2020-01-16
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- Add `message.IsIntersectingN()` and `IsSubsetN()`
-- Add `message.IntersectionN()` and `UnionN()` and `DiffN()`
+- Add `message.IsIntersectingN()`, `IsSubsetN()`, `IntersectionN()`, `UnionN()` and `DiffN()`
+- Add `message.IsIntersectingT()`, `IsSubsetT()`, `IntersectionT()`, `UnionT()` and `DiffT()`
 
 ## [0.2.1] - 2020-01-16
 

--- a/message/name.go
+++ b/message/name.go
@@ -25,7 +25,9 @@ type NameCollection interface {
 	Each(fn func(Name) bool) bool
 }
 
-// IsIntersectingN returns true if a and b contain any of the same names.
+// IsIntersectingN returns true if a and b are intersecting.
+//
+// That is, it returns true if a and b contain any of the same names.
 func IsIntersectingN(a, b NameCollection) bool {
 	return !a.Each(func(n Name) bool {
 		return !b.Has(n)
@@ -33,6 +35,8 @@ func IsIntersectingN(a, b NameCollection) bool {
 }
 
 // IsSubsetN returns true if sub is a (non-strict) subset of sup.
+//
+// That is, it returns true if sup contains all of the names in sub.
 func IsSubsetN(sub, sup NameCollection) bool {
 	return sub.Each(func(n Name) bool {
 		return sup.Has(n)

--- a/message/name.go
+++ b/message/name.go
@@ -28,6 +28,8 @@ type NameCollection interface {
 // IsIntersectingN returns true if a and b are intersecting.
 //
 // That is, it returns true if a and b contain any of the same names.
+//
+// See https://en.wikipedia.org/wiki/Set_(mathematics)#Intersections.
 func IsIntersectingN(a, b NameCollection) bool {
 	return !a.Each(func(n Name) bool {
 		return !b.Has(n)
@@ -37,6 +39,8 @@ func IsIntersectingN(a, b NameCollection) bool {
 // IsSubsetN returns true if sub is a (non-strict) subset of sup.
 //
 // That is, it returns true if sup contains all of the names in sub.
+//
+// See https://en.wikipedia.org/wiki/Set_(mathematics)#Subsets.
 func IsSubsetN(sub, sup NameCollection) bool {
 	return sub.Each(func(n Name) bool {
 		return sup.Has(n)

--- a/message/name.go
+++ b/message/name.go
@@ -25,6 +25,20 @@ type NameCollection interface {
 	Each(fn func(Name) bool) bool
 }
 
+// IsIntersectingN returns true if a and b contain any of the same names.
+func IsIntersectingN(a, b NameCollection) bool {
+	return !a.Each(func(n Name) bool {
+		return !b.Has(n)
+	})
+}
+
+// IsSubsetN returns true if sub is a (non-strict) subset of sup.
+func IsSubsetN(sub, sup NameCollection) bool {
+	return sub.Each(func(n Name) bool {
+		return sup.Has(n)
+	})
+}
+
 // Name is the fully-qualified name of a message type.
 type Name struct {
 	n string

--- a/message/name_test.go
+++ b/message/name_test.go
@@ -7,6 +7,52 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("func IsIntersectingN()", func() {
+	It("returns true for identical sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsIntersectingN(a, b)).To(BeTrue())
+	})
+
+	It("returns false for disjoint sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageC1, fixtures.MessageD1)
+		Expect(IsIntersectingN(a, b)).To(BeFalse())
+	})
+
+	It("returns true for intersecting sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageB1, fixtures.MessageC1)
+		Expect(IsIntersectingN(a, b)).To(BeTrue())
+	})
+})
+
+var _ = Describe("func IsSubsetN()", func() {
+	It("returns true for identical sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsSubsetN(a, b)).To(BeTrue())
+	})
+
+	It("returns true for strict subsets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+		Expect(IsSubsetN(a, b)).To(BeTrue())
+	})
+
+	It("returns false for supersets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+		b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsSubsetN(a, b)).To(BeFalse())
+	})
+
+	It("returns false for disjoint sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageC1, fixtures.MessageD1)
+		Expect(IsSubsetN(a, b)).To(BeFalse())
+	})
+})
+
 var _ = Describe("type Name", func() {
 	Describe("func NameOf()", func() {
 		It("returns the fully-qualified name", func() {

--- a/message/nameset.go
+++ b/message/nameset.go
@@ -82,6 +82,7 @@ func DiffN(a, b NameCollection) NameSet {
 		if !b.Has(n) {
 			r.Add(n)
 		}
+
 		return true
 	})
 

--- a/message/nameset.go
+++ b/message/nameset.go
@@ -33,7 +33,10 @@ func NamesOf(messages ...dogma.Message) NameSet {
 // IntersectionN returns the intersection of the given collections.
 //
 // That is, it returns a set containing only those names that are present in all
-// of the given collections.
+// of the given collections. It returns an empty set if no collections are
+// given.
+//
+// See https://en.wikipedia.org/wiki/Intersection_(set_theory).
 func IntersectionN(collections ...NameCollection) NameSet {
 	r := NameSet{}
 
@@ -57,7 +60,9 @@ func IntersectionN(collections ...NameCollection) NameSet {
 // UnionN returns the union of the given collections.
 //
 // That is, it returns a set containing all of the names present in all of the
-// given collections.
+// given collections. It returns an empty set if no collections are given.
+//
+// See https://en.wikipedia.org/wiki/Union_(set_theory).
 func UnionN(collections ...NameCollection) NameSet {
 	r := NameSet{}
 
@@ -75,6 +80,8 @@ func UnionN(collections ...NameCollection) NameSet {
 //
 // That is, it returns a set containing all of the names present in a that are
 // not present in b.
+//
+// See https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement.
 func DiffN(a, b NameCollection) NameSet {
 	r := NameSet{}
 

--- a/message/nameset.go
+++ b/message/nameset.go
@@ -30,6 +30,64 @@ func NamesOf(messages ...dogma.Message) NameSet {
 	return s
 }
 
+// IntersectionN returns the intersection of the given collections.
+//
+// That is, it returns a set containing only those names that are present in all
+// of the given collections.
+func IntersectionN(collections ...NameCollection) NameSet {
+	r := NameSet{}
+
+	if len(collections) > 0 {
+		collections[0].Each(func(n Name) bool {
+			for _, c := range collections[1:] {
+				if !c.Has(n) {
+					return true
+				}
+			}
+
+			r.Add(n)
+
+			return true
+		})
+	}
+
+	return r
+}
+
+// UnionN returns the union of the given collections.
+//
+// That is, it returns a set containing all of the names present in all of the
+// given collections.
+func UnionN(collections ...NameCollection) NameSet {
+	r := NameSet{}
+
+	for _, c := range collections {
+		c.Each(func(n Name) bool {
+			r.Add(n)
+			return true
+		})
+	}
+
+	return r
+}
+
+// DiffN returns the difference between a and b.
+//
+// That is, it returns a set containing all of the names present in a that are
+// not present in b.
+func DiffN(a, b NameCollection) NameSet {
+	r := NameSet{}
+
+	a.Each(func(n Name) bool {
+		if !b.Has(n) {
+			r.Add(n)
+		}
+		return true
+	})
+
+	return r
+}
+
 // Has returns true if s contains n.
 func (s NameSet) Has(n Name) bool {
 	_, ok := s[n]

--- a/message/nameset_test.go
+++ b/message/nameset_test.go
@@ -3,6 +3,7 @@ package message_test
 import (
 	. "github.com/dogmatiq/configkit/fixtures"
 	. "github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -33,6 +34,90 @@ var _ = Describe("type NameSet", func() {
 				MessageATypeName: struct{}{},
 				MessageBTypeName: struct{}{},
 			}))
+		})
+	})
+
+	Describe("func IntersectionN()", func() {
+		It("returns an empty set if no sets are given", func() {
+			Expect(IntersectionN()).To(BeEmpty())
+		})
+
+		It("returns the original set if a single set is given", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(IntersectionN(a)).To(Equal(a))
+		})
+
+		It("returns the original set for identical sets", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			c := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(IntersectionN(a, b, c)).To(Equal(a))
+		})
+
+		It("returns an empty set for disjoint sets", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := NamesOf(fixtures.MessageC1, fixtures.MessageD1) // disjoint to a
+			c := NamesOf(fixtures.MessageC1, fixtures.MessageD1) // same as c
+			Expect(IntersectionN(a, b, c)).To(BeEmpty())
+		})
+
+		It("returns the intersection", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+			b := NamesOf(fixtures.MessageB1, fixtures.MessageC1, fixtures.MessageD1)
+			c := NamesOf(fixtures.MessageC1, fixtures.MessageD1, fixtures.MessageE1)
+			Expect(IntersectionN(a, b, c)).To(Equal(NamesOf(fixtures.MessageC1)))
+		})
+	})
+
+	Describe("func UnionN()", func() {
+		It("returns an empty set if no sets are given", func() {
+			Expect(UnionN()).To(BeEmpty())
+		})
+
+		It("returns the original set if a single set is given", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(UnionN(a)).To(Equal(a))
+		})
+
+		It("returns the original set for identical sets", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			c := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(UnionN(a, b, c)).To(Equal(a))
+		})
+
+		It("returns the union", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+			b := NamesOf(fixtures.MessageB1, fixtures.MessageC1, fixtures.MessageD1)
+			c := NamesOf(fixtures.MessageC1, fixtures.MessageD1, fixtures.MessageE1)
+
+			Expect(UnionN(a, b, c)).To(Equal(NamesOf(
+				fixtures.MessageA1,
+				fixtures.MessageB1,
+				fixtures.MessageC1,
+				fixtures.MessageD1,
+				fixtures.MessageE1,
+			)))
+		})
+	})
+
+	Describe("func DiffN()", func() {
+		It("returns an empty set for identical sets", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(DiffN(a, b)).To(BeEmpty())
+		})
+
+		It("returns an the original set for disjoint sets", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := NamesOf(fixtures.MessageC1, fixtures.MessageD1)
+			Expect(DiffN(a, b)).To(Equal(a))
+		})
+
+		It("returns the diff", func() {
+			a := NamesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+			b := NamesOf(fixtures.MessageB1, fixtures.MessageC1)
+			Expect(DiffN(a, b)).To(Equal(NamesOf(fixtures.MessageA1)))
 		})
 	})
 

--- a/message/type.go
+++ b/message/type.go
@@ -24,6 +24,24 @@ type TypeCollection interface {
 	Each(fn func(Type) bool) bool
 }
 
+// IsIntersectingT returns true if a and b are intersecting.
+//
+// That is, it returns true if a and b contain any of the same types.
+func IsIntersectingT(a, b TypeCollection) bool {
+	return !a.Each(func(t Type) bool {
+		return !b.Has(t)
+	})
+}
+
+// IsSubsetT returns true if sub is a (non-strict) subset of sup.
+//
+// That is, it returns true if sup contains all of the types in sub.
+func IsSubsetT(sub, sup TypeCollection) bool {
+	return sub.Each(func(t Type) bool {
+		return sup.Has(t)
+	})
+}
+
 // Type represents the type of a Dogma message.
 type Type struct {
 	n  Name

--- a/message/type.go
+++ b/message/type.go
@@ -27,6 +27,8 @@ type TypeCollection interface {
 // IsIntersectingT returns true if a and b are intersecting.
 //
 // That is, it returns true if a and b contain any of the same types.
+//
+// See https://en.wikipedia.org/wiki/Set_(mathematics)#Intersections.
 func IsIntersectingT(a, b TypeCollection) bool {
 	return !a.Each(func(t Type) bool {
 		return !b.Has(t)
@@ -36,6 +38,8 @@ func IsIntersectingT(a, b TypeCollection) bool {
 // IsSubsetT returns true if sub is a (non-strict) subset of sup.
 //
 // That is, it returns true if sup contains all of the types in sub.
+//
+// See https://en.wikipedia.org/wiki/Set_(mathematics)#Subsets.
 func IsSubsetT(sub, sup TypeCollection) bool {
 	return sub.Each(func(t Type) bool {
 		return sup.Has(t)

--- a/message/type_test.go
+++ b/message/type_test.go
@@ -9,6 +9,52 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("func IsIntersectingT()", func() {
+	It("returns true for identical sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsIntersectingT(a, b)).To(BeTrue())
+	})
+
+	It("returns false for disjoint sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageC1, fixtures.MessageD1)
+		Expect(IsIntersectingT(a, b)).To(BeFalse())
+	})
+
+	It("returns true for intersecting sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageB1, fixtures.MessageC1)
+		Expect(IsIntersectingT(a, b)).To(BeTrue())
+	})
+})
+
+var _ = Describe("func IsSubsetT()", func() {
+	It("returns true for identical sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsSubsetT(a, b)).To(BeTrue())
+	})
+
+	It("returns true for strict subsets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+		Expect(IsSubsetT(a, b)).To(BeTrue())
+	})
+
+	It("returns false for supersets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+		b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsSubsetT(a, b)).To(BeFalse())
+	})
+
+	It("returns false for disjoint sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageC1, fixtures.MessageD1)
+		Expect(IsSubsetT(a, b)).To(BeFalse())
+	})
+})
+
 var _ = Describe("type Type", func() {
 	Describe("func TypeOf()", func() {
 		It("returns values that compare as equal for messages of the same type", func() {

--- a/message/typeset.go
+++ b/message/typeset.go
@@ -30,6 +30,65 @@ func TypesOf(messages ...dogma.Message) TypeSet {
 	return s
 }
 
+// IntersectionT returns the intersection of the given collections.
+//
+// That is, it returns a set containing only those types that are present in all
+// of the given collections.
+func IntersectionT(collections ...TypeCollection) TypeSet {
+	r := TypeSet{}
+
+	if len(collections) > 0 {
+		collections[0].Each(func(t Type) bool {
+			for _, c := range collections[1:] {
+				if !c.Has(t) {
+					return true
+				}
+			}
+
+			r.Add(t)
+
+			return true
+		})
+	}
+
+	return r
+}
+
+// UnionT returns the union of the given collections.
+//
+// That is, it returns a set containing all of the types present in all of the
+// given collections.
+func UnionT(collections ...TypeCollection) TypeSet {
+	r := TypeSet{}
+
+	for _, c := range collections {
+		c.Each(func(t Type) bool {
+			r.Add(t)
+			return true
+		})
+	}
+
+	return r
+}
+
+// DiffT returns the difference between a and b.
+//
+// That is, it returns a set containing all of the types present in a that are
+// not present in b.
+func DiffT(a, b TypeCollection) TypeSet {
+	r := TypeSet{}
+
+	a.Each(func(t Type) bool {
+		if !b.Has(t) {
+			r.Add(t)
+		}
+
+		return true
+	})
+
+	return r
+}
+
 // Has returns true if s contains t.
 func (s TypeSet) Has(t Type) bool {
 	_, ok := s[t]

--- a/message/typeset.go
+++ b/message/typeset.go
@@ -33,7 +33,10 @@ func TypesOf(messages ...dogma.Message) TypeSet {
 // IntersectionT returns the intersection of the given collections.
 //
 // That is, it returns a set containing only those types that are present in all
-// of the given collections.
+// of the given collections. It returns an empty set if no collections are
+// given.
+//
+// See https://en.wikipedia.org/wiki/Intersection_(set_theory).
 func IntersectionT(collections ...TypeCollection) TypeSet {
 	r := TypeSet{}
 
@@ -57,7 +60,9 @@ func IntersectionT(collections ...TypeCollection) TypeSet {
 // UnionT returns the union of the given collections.
 //
 // That is, it returns a set containing all of the types present in all of the
-// given collections.
+// given collections. It returns an empty set if no collections are given.
+//
+// See https://en.wikipedia.org/wiki/Union_(set_theory).
 func UnionT(collections ...TypeCollection) TypeSet {
 	r := TypeSet{}
 
@@ -75,6 +80,8 @@ func UnionT(collections ...TypeCollection) TypeSet {
 //
 // That is, it returns a set containing all of the types present in a that are
 // not present in b.
+//
+// See https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement.
 func DiffT(a, b TypeCollection) TypeSet {
 	r := TypeSet{}
 

--- a/message/typeset_test.go
+++ b/message/typeset_test.go
@@ -3,6 +3,7 @@ package message_test
 import (
 	. "github.com/dogmatiq/configkit/fixtures"
 	. "github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -33,6 +34,90 @@ var _ = Describe("type TypeSet", func() {
 				MessageAType: struct{}{},
 				MessageBType: struct{}{},
 			}))
+		})
+	})
+
+	Describe("func IntersectionT()", func() {
+		It("returns an empty set if no sets are given", func() {
+			Expect(IntersectionT()).To(BeEmpty())
+		})
+
+		It("returns the original set if a single set is given", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(IntersectionT(a)).To(Equal(a))
+		})
+
+		It("returns the original set for identical sets", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			c := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(IntersectionT(a, b, c)).To(Equal(a))
+		})
+
+		It("returns an empty set for disjoint sets", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := TypesOf(fixtures.MessageC1, fixtures.MessageD1) // disjoint to a
+			c := TypesOf(fixtures.MessageC1, fixtures.MessageD1) // same as c
+			Expect(IntersectionT(a, b, c)).To(BeEmpty())
+		})
+
+		It("returns the intersection", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+			b := TypesOf(fixtures.MessageB1, fixtures.MessageC1, fixtures.MessageD1)
+			c := TypesOf(fixtures.MessageC1, fixtures.MessageD1, fixtures.MessageE1)
+			Expect(IntersectionT(a, b, c)).To(Equal(TypesOf(fixtures.MessageC1)))
+		})
+	})
+
+	Describe("func UnionT()", func() {
+		It("returns an empty set if no sets are given", func() {
+			Expect(UnionT()).To(BeEmpty())
+		})
+
+		It("returns the original set if a single set is given", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(UnionT(a)).To(Equal(a))
+		})
+
+		It("returns the original set for identical sets", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			c := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(UnionT(a, b, c)).To(Equal(a))
+		})
+
+		It("returns the union", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+			b := TypesOf(fixtures.MessageB1, fixtures.MessageC1, fixtures.MessageD1)
+			c := TypesOf(fixtures.MessageC1, fixtures.MessageD1, fixtures.MessageE1)
+
+			Expect(UnionT(a, b, c)).To(Equal(TypesOf(
+				fixtures.MessageA1,
+				fixtures.MessageB1,
+				fixtures.MessageC1,
+				fixtures.MessageD1,
+				fixtures.MessageE1,
+			)))
+		})
+	})
+
+	Describe("func DiffT()", func() {
+		It("returns an empty set for identical sets", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			Expect(DiffT(a, b)).To(BeEmpty())
+		})
+
+		It("returns an the original set for disjoint sets", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+			b := TypesOf(fixtures.MessageC1, fixtures.MessageD1)
+			Expect(DiffT(a, b)).To(Equal(a))
+		})
+
+		It("returns the diff", func() {
+			a := TypesOf(fixtures.MessageA1, fixtures.MessageB1, fixtures.MessageC1)
+			b := TypesOf(fixtures.MessageB1, fixtures.MessageC1)
+			Expect(DiffT(a, b)).To(Equal(TypesOf(fixtures.MessageA1)))
 		})
 	})
 


### PR DESCRIPTION
This PR adds various set operations for `NameSet` and `TypeSet`.  Where possible the implementations work generically on the `NameCollection` and `TypeCollection` interfaces.