### PR TITLE
Add methods for obtaining type-specific slices from handler sets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- Add `HandlerSet.Range[Aggregates|Processes|Integrations|Projections]()`
-- Add `RichHandlerSet.Range[Aggregates|Processes|Integrations|Projections]()`
+- Add `HandlerSet.RangeAggregates()`, `RangeProcesses()`, `RangeIntegrations()` and `RangeProjections()`
+- Add `HandlerSet.Aggregates()`, `Processes()`, `Integrations()` and `Projections()`
+- Add `RichHandlerSet.Aggregates()`, `Processes()`, `Integrations()` and `Projections()`
+- Add `RichHandlerSet.RangeAggregates()`, `RangeProcesses()`, `RangeIntegrations()` and `RangeProjections()`
 
 ## [0.2.2] - 2020-01-29
 

--- a/handlerset.go
+++ b/handlerset.go
@@ -147,6 +147,58 @@ func (s HandlerSet) AcceptVisitor(ctx context.Context, v Visitor) error {
 	return nil
 }
 
+// Aggregates returns a slice containing the aggregate handlers in the set.
+func (s HandlerSet) Aggregates() []Aggregate {
+	var r []Aggregate
+
+	for _, h := range s {
+		if h.HandlerType() == AggregateHandlerType {
+			r = append(r, h)
+		}
+	}
+
+	return r
+}
+
+// Processes returns a slice containing the process handlers in the set.
+func (s HandlerSet) Processes() []Process {
+	var r []Process
+
+	for _, h := range s {
+		if h.HandlerType() == ProcessHandlerType {
+			r = append(r, h)
+		}
+	}
+
+	return r
+}
+
+// Integrations returns a slice containing the integration handlers in the set.
+func (s HandlerSet) Integrations() []Integration {
+	var r []Integration
+
+	for _, h := range s {
+		if h.HandlerType() == IntegrationHandlerType {
+			r = append(r, h)
+		}
+	}
+
+	return r
+}
+
+// Projections returns a slice containing the projection handlers in the set.
+func (s HandlerSet) Projections() []Projection {
+	var r []Projection
+
+	for _, h := range s {
+		if h.HandlerType() == ProjectionHandlerType {
+			r = append(r, h)
+		}
+	}
+
+	return r
+}
+
 // RangeAggregates invokes fn once for each aggregate handler in the set.
 //
 // Iteration stops when fn returns false or once fn has been invoked for all
@@ -384,6 +436,58 @@ func (s RichHandlerSet) AcceptRichVisitor(ctx context.Context, v RichVisitor) er
 	}
 
 	return nil
+}
+
+// Aggregates returns a slice containing the aggregate handlers in the set.
+func (s RichHandlerSet) Aggregates() []RichAggregate {
+	var r []RichAggregate
+
+	for _, h := range s {
+		if x, ok := h.(RichAggregate); ok {
+			r = append(r, x)
+		}
+	}
+
+	return r
+}
+
+// Processes returns a slice containing the process handlers in the set.
+func (s RichHandlerSet) Processes() []RichProcess {
+	var r []RichProcess
+
+	for _, h := range s {
+		if x, ok := h.(RichProcess); ok {
+			r = append(r, x)
+		}
+	}
+
+	return r
+}
+
+// Integrations returns a slice containing the integration handlers in the set.
+func (s RichHandlerSet) Integrations() []RichIntegration {
+	var r []RichIntegration
+
+	for _, h := range s {
+		if x, ok := h.(RichIntegration); ok {
+			r = append(r, x)
+		}
+	}
+
+	return r
+}
+
+// Projections returns a slice containing the projection handlers in the set.
+func (s RichHandlerSet) Projections() []RichProjection {
+	var r []RichProjection
+
+	for _, h := range s {
+		if x, ok := h.(RichProjection); ok {
+			r = append(r, x)
+		}
+	}
+
+	return r
 }
 
 // RangeAggregates invokes fn once for each aggregate handler in the set.

--- a/handlerset_test.go
+++ b/handlerset_test.go
@@ -302,7 +302,7 @@ var _ = Describe("type HandlerSet", func() {
 		})
 	})
 
-	Context("ranging functions", func() {
+	Context("type-specific filtering", func() {
 		var (
 			aggregate1, aggregate2     Aggregate
 			process1, process2         Process
@@ -381,6 +381,30 @@ var _ = Describe("type HandlerSet", func() {
 			set.Add(integration2)
 			set.Add(projection1)
 			set.Add(projection2)
+		})
+
+		Describe("func Aggregates()", func() {
+			It("returns a slice containing the aggregates", func() {
+				Expect(set.Aggregates()).To(ConsistOf(aggregate1, aggregate2))
+			})
+		})
+
+		Describe("func Processes()", func() {
+			It("returns a slice containing the processes", func() {
+				Expect(set.Processes()).To(ConsistOf(process1, process2))
+			})
+		})
+
+		Describe("func Integrations()", func() {
+			It("returns a slice containing the integrations", func() {
+				Expect(set.Integrations()).To(ConsistOf(integration1, integration2))
+			})
+		})
+
+		Describe("func Projections()", func() {
+			It("returns a slice containing the projections", func() {
+				Expect(set.Projections()).To(ConsistOf(projection1, projection2))
+			})
 		})
 
 		Describe("func RangeAggregates()", func() {
@@ -778,7 +802,7 @@ var _ = Describe("type RichHandlerSet", func() {
 		})
 	})
 
-	Context("ranging functions", func() {
+	Context("type-specific filtering", func() {
 		var (
 			aggregate1, aggregate2     RichAggregate
 			process1, process2         RichProcess
@@ -857,6 +881,30 @@ var _ = Describe("type RichHandlerSet", func() {
 			set.Add(integration2)
 			set.Add(projection1)
 			set.Add(projection2)
+		})
+
+		Describe("func Aggregates()", func() {
+			It("returns a slice containing the aggregates", func() {
+				Expect(set.Aggregates()).To(ConsistOf(aggregate1, aggregate2))
+			})
+		})
+
+		Describe("func Processes()", func() {
+			It("returns a slice containing the processes", func() {
+				Expect(set.Processes()).To(ConsistOf(process1, process2))
+			})
+		})
+
+		Describe("func Integrations()", func() {
+			It("returns a slice containing the integrations", func() {
+				Expect(set.Integrations()).To(ConsistOf(integration1, integration2))
+			})
+		})
+
+		Describe("func Projections()", func() {
+			It("returns a slice containing the projections", func() {
+				Expect(set.Projections()).To(ConsistOf(projection1, projection2))
+			})
 		})
 
 		Describe("func RangeAggregates()", func() {


### PR DESCRIPTION
This PR adds methods for obtaining strictly-typed slices of specific handler types from `HandlerSet` and `RichHandlerSet`.