### PR TITLE
Add `discovery.TargetExecutor` and `ClientExecutor`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `discovery.TargetExecutor` and `ClientExecutor`
+- Add `discovery.Connector.Ignore`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add `discovery.TargetExecutor` and `ClientExecutor`
+
 ### Changed
 
 - **[BC]** Change the internal gRPC API namespace from `dogma.configkit.v1` to `dogma.config.v1`
 - **[BC]** Change `api.Client` to an interface
+- **[BC]** `discovery.Connector` no longer implements `TargetObserver`, instead use a `TargetExecutor` to call `Connector.Run()`
 
 ## [0.3.1] - 2020-03-08
 

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -79,14 +79,17 @@ func (s *ClientObserverSet) ClientDisconnected(c *Client) {
 	})
 }
 
+// ClientTask is a function executed by a ClientExecutor.
+type ClientTask func(context.Context, *Client)
+
 // ClientExecutor is a ClientObserver that executes a function in a new
 // goroutine whenever a client connects.
 type ClientExecutor struct {
 	executor
 
-	// Func is the function to execute when a client connects.
+	// Task is the function to execute when a client connects.
 	// The context is canceled when the target becomes unavailable.
-	Func func(context.Context, *Client)
+	Task ClientTask
 
 	// Parent is the parent context under which the function is called.
 	// If it is nil, context.Background() is used.
@@ -96,7 +99,7 @@ type ClientExecutor struct {
 // ClientConnected starts a new goroutine for the given client.
 func (e *ClientExecutor) ClientConnected(c *Client) {
 	e.start(e.Parent, c, func(ctx context.Context) {
-		e.Func(ctx, c)
+		e.Task(ctx, c)
 	})
 }
 

--- a/api/discovery/client_test.go
+++ b/api/discovery/client_test.go
@@ -200,7 +200,7 @@ var _ = Describe("type ClientExecutor", func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
 
 		exec = &ClientExecutor{
-			Func: func(context.Context, *Client) {},
+			Task: func(context.Context, *Client) {},
 		}
 
 		client = &Client{}
@@ -214,7 +214,7 @@ var _ = Describe("type ClientExecutor", func() {
 		It("starts a goroutine for the given client", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(_ context.Context, c *Client) {
+			exec.Task = func(_ context.Context, c *Client) {
 				defer GinkgoRecover()
 				defer close(barrier)
 
@@ -243,7 +243,7 @@ var _ = Describe("type ClientExecutor", func() {
 		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(funcCtx context.Context, c *Client) {
+			exec.Task = func(funcCtx context.Context, c *Client) {
 				defer GinkgoRecover()
 				defer close(barrier)
 

--- a/api/discovery/client_test.go
+++ b/api/discovery/client_test.go
@@ -1,6 +1,9 @@
 package discovery_test
 
 import (
+	"context"
+	"time"
+
 	. "github.com/dogmatiq/configkit/api/discovery"
 	"github.com/dogmatiq/configkit/api/fixtures" // can't dot-import due to conflict
 	. "github.com/onsi/ginkgo"
@@ -179,6 +182,91 @@ var _ = Describe("type ClientObserverSet", func() {
 			}
 
 			set.UnregisterClientObserver(obs1)
+		})
+	})
+})
+
+var _ ClientObserver = (*ClientExecutor)(nil)
+
+var _ = Describe("type ClientExecutor", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+		exec   *ClientExecutor
+		client *Client
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		exec = &ClientExecutor{
+			Func: func(context.Context, *Client) {},
+		}
+
+		client = &Client{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func ClientConnected()", func() {
+		It("starts a goroutine for the given client", func() {
+			barrier := make(chan struct{})
+
+			exec.Func = func(_ context.Context, c *Client) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				Expect(c).To(Equal(client))
+			}
+
+			exec.ClientConnected(client)
+			defer exec.ClientDisconnected(client)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the client is already connected", func() {
+			exec.ClientConnected(client)
+			defer exec.ClientDisconnected(client)
+
+			exec.ClientConnected(client)
+		})
+	})
+
+	Describe("func ClientDisconnected()", func() {
+		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
+			barrier := make(chan struct{})
+
+			exec.Func = func(funcCtx context.Context, c *Client) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				select {
+				case <-funcCtx.Done():
+					// ok
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			}
+
+			exec.ClientConnected(client)
+			exec.ClientDisconnected(client)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the client is already disconnected", func() {
+			exec.ClientDisconnected(client)
 		})
 	})
 })

--- a/api/discovery/connector.go
+++ b/api/discovery/connector.go
@@ -21,6 +21,10 @@ type Connector struct {
 	// If it is nil, DefaultDialer is used.
 	Dial Dialer
 
+	// Ignore is a predicate function that returns true if the given target
+	// should be ignored.
+	Ignore func(*Target) bool
+
 	// BackoffStrategy controls how long to wait between failures to dial a
 	// discovered target.
 	BackoffStrategy backoff.Strategy
@@ -34,6 +38,10 @@ type Connector struct {
 //
 // It retries until ctx is canceled.
 func (c *Connector) Watch(ctx context.Context, t *Target) error {
+	if c.Ignore != nil && c.Ignore(t) {
+		return nil
+	}
+
 	ctr := &backoff.Counter{
 		Strategy: c.BackoffStrategy,
 	}

--- a/api/discovery/connector.go
+++ b/api/discovery/connector.go
@@ -115,7 +115,7 @@ func (c *Connector) publish(
 	c.Observer.ClientConnected(client)
 	defer c.Observer.ClientDisconnected(client)
 
-	// We've successfully queried the server, so if there is an error now its a
+	// We've successfully queried the server, so if there is an error now it's a
 	// regular disconnection and we should retry immediately, therefore we reset
 	// the failure counter.
 	ctr.Reset()

--- a/api/discovery/connector.go
+++ b/api/discovery/connector.go
@@ -25,8 +25,7 @@ type Connector struct {
 	// should be ignored.
 	Ignore func(*Target) bool
 
-	// BackoffStrategy controls how long to wait between failures to dial a
-	// discovered target.
+	// BackoffStrategy controls how long to wait between dialing retries.
 	BackoffStrategy backoff.Strategy
 
 	// Logger is the target for log messages about dialing failures.

--- a/api/discovery/connector.go
+++ b/api/discovery/connector.go
@@ -32,11 +32,11 @@ type Connector struct {
 	Logger logging.Logger
 }
 
-// Watch connects to a target in order to publish client connect/disconnect
+// Run connects to a target in order to publish client connect/disconnect
 // notifications to the observer.
 //
 // It retries until ctx is canceled.
-func (c *Connector) Watch(ctx context.Context, t *Target) error {
+func (c *Connector) Run(ctx context.Context, t *Target) error {
 	if c.Ignore != nil && c.Ignore(t) {
 		return nil
 	}
@@ -82,15 +82,15 @@ func (c *Connector) dial(
 	}
 	defer conn.Close()
 
-	return c.publish(ctx, ctr, conn, t)
+	return c.watch(ctx, ctr, conn, t)
 }
 
-// publish checks if conn supports the config API and notifies the observer
+// watch checks if conn supports the config API and notifies the observer
 // accordingly.
 //
 // It blocks until ctx is canceled or the connection is severed, at which point
 // the observer is notified of the disconnection.
-func (c *Connector) publish(
+func (c *Connector) watch(
 	ctx context.Context,
 	ctr *backoff.Counter,
 	conn *grpc.ClientConn,

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -108,6 +108,19 @@ var _ = Describe("type Connector", func() {
 			})
 		})
 
+		Context("when target is ignored", func() {
+			BeforeEach(func() {
+				connector.Ignore = func(t *Target) bool {
+					return t == target
+				}
+			})
+
+			It("returns immediately", func() {
+				err := connector.Watch(ctx, target)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
 		Context("when the server implements the config API", func() {
 			BeforeEach(func() {
 				app := &Application{

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -77,7 +77,7 @@ var _ = Describe("type Connector", func() {
 		cancel()
 	})
 
-	Describe("Connect()", func() {
+	Describe("Watch()", func() {
 		Context("when dialing fails", func() {
 			BeforeEach(func() {
 				listener.Close()

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -108,7 +108,7 @@ var _ = Describe("type Connector", func() {
 			})
 		})
 
-		Context("when target is ignored", func() {
+		Context("when the target is ignored", func() {
 			BeforeEach(func() {
 				connector.Ignore = func(t *Target) bool {
 					return t == target

--- a/api/discovery/executor.go
+++ b/api/discovery/executor.go
@@ -1,0 +1,68 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+)
+
+// executor provides shared logic to TargetExecutor and ClientExecutor.
+type executor struct {
+	m     sync.Mutex
+	tasks map[interface{}]task
+}
+
+type task struct {
+	Cancel context.CancelFunc
+	Done   chan struct{}
+}
+
+func (e *executor) start(
+	parent context.Context,
+	key interface{},
+	fn func(context.Context),
+) {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	if e.tasks == nil {
+		e.tasks = map[interface{}]task{}
+	} else if _, ok := e.tasks[key]; ok {
+		return
+	}
+
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+
+	e.tasks[key] = task{
+		cancel,
+		done,
+	}
+
+	go func() {
+		defer close(done)
+		fn(ctx)
+	}()
+}
+
+func (e *executor) stop(key interface{}) {
+	if task, ok := e.remove(key); ok {
+		task.Cancel()
+		<-task.Done
+	}
+}
+
+func (e *executor) remove(key interface{}) (task, bool) {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	task, ok := e.tasks[key]
+	if ok {
+		delete(e.tasks, key)
+	}
+
+	return task, ok
+}

--- a/api/discovery/target.go
+++ b/api/discovery/target.go
@@ -81,14 +81,17 @@ func (s *TargetObserverSet) TargetUnavailable(t *Target) {
 	})
 }
 
+// TargetTask is a function executed by a TargetExecutor.
+type TargetTask func(context.Context, *Target)
+
 // TargetExecutor is a TargetObserver that executes a function in a new
 // goroutine whenever a target becomes available.
 type TargetExecutor struct {
 	executor
 
-	// Func is the function to execute when a target becomes available.
+	// Task is the function to execute when a target becomes available.
 	// The context is canceled when the target becomes unavailable.
-	Func func(context.Context, *Target)
+	Task TargetTask
 
 	// Parent is the parent context under which the function is called.
 	// If it is nil, context.Background() is used.
@@ -98,7 +101,7 @@ type TargetExecutor struct {
 // TargetAvailable starts a new goroutine for the given target.
 func (e *TargetExecutor) TargetAvailable(t *Target) {
 	e.start(e.Parent, t, func(ctx context.Context) {
-		e.Func(ctx, t)
+		e.Task(ctx, t)
 	})
 }
 

--- a/api/discovery/target_test.go
+++ b/api/discovery/target_test.go
@@ -1,6 +1,9 @@
 package discovery_test
 
 import (
+	"context"
+	"time"
+
 	. "github.com/dogmatiq/configkit/api/discovery"
 	"github.com/dogmatiq/configkit/api/fixtures" // can't dot-import due to conflict
 	. "github.com/onsi/ginkgo"
@@ -179,6 +182,91 @@ var _ = Describe("type TargetObserverSet", func() {
 			}
 
 			set.UnregisterTargetObserver(obs1)
+		})
+	})
+})
+
+var _ TargetObserver = (*TargetExecutor)(nil)
+
+var _ = Describe("type TargetExecutor", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+		exec   *TargetExecutor
+		target *Target
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		exec = &TargetExecutor{
+			Func: func(context.Context, *Target) {},
+		}
+
+		target = &Target{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func TargetAvailable()", func() {
+		It("starts a goroutine for the given target", func() {
+			barrier := make(chan struct{})
+
+			exec.Func = func(_ context.Context, t *Target) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				Expect(t).To(Equal(target))
+			}
+
+			exec.TargetAvailable(target)
+			defer exec.TargetUnavailable(target)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the target is already available", func() {
+			exec.TargetAvailable(target)
+			defer exec.TargetUnavailable(target)
+
+			exec.TargetAvailable(target)
+		})
+	})
+
+	Describe("func TargetUnavailable()", func() {
+		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
+			barrier := make(chan struct{})
+
+			exec.Func = func(funcCtx context.Context, t *Target) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				select {
+				case <-funcCtx.Done():
+					// ok
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			}
+
+			exec.TargetAvailable(target)
+			exec.TargetUnavailable(target)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the target is already unavailable", func() {
+			exec.TargetUnavailable(target)
 		})
 	})
 })

--- a/api/discovery/target_test.go
+++ b/api/discovery/target_test.go
@@ -200,7 +200,7 @@ var _ = Describe("type TargetExecutor", func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
 
 		exec = &TargetExecutor{
-			Func: func(context.Context, *Target) {},
+			Task: func(context.Context, *Target) {},
 		}
 
 		target = &Target{}
@@ -214,7 +214,7 @@ var _ = Describe("type TargetExecutor", func() {
 		It("starts a goroutine for the given target", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(_ context.Context, t *Target) {
+			exec.Task = func(_ context.Context, t *Target) {
 				defer GinkgoRecover()
 				defer close(barrier)
 
@@ -243,7 +243,7 @@ var _ = Describe("type TargetExecutor", func() {
 		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(funcCtx context.Context, t *Target) {
+			exec.Task = func(funcCtx context.Context, t *Target) {
 				defer GinkgoRecover()
 				defer close(barrier)
 


### PR DESCRIPTION
This is now based on #51, it will need to be rebased after that is merged.

This PR adds "executors" for targets and clients.

Executors are observers that start a goroutine whenever the target/client is available/connected respectively. A context associated with each goroutine is canceled when the target/client becomes unavailable/disconnected.

The `Connector` struct (and it's helper `watcher`) previously implemented some very similar logic. It has been refactored such that it can be used with a `TargetExecutor`.