### PR TITLE
Add application-based observer and supporting types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Add `discovery.TargetExecutor` and `ClientExecutor`
 - Add `discovery.Connector.Ignore`
+- Add `discovery.ApplicationObserver`, `ApplicationObserverSet` and `ApplicationExecutor`
+- Add `discovery.Inspector`
 
 ### Changed
 

--- a/api/discovery/application.go
+++ b/api/discovery/application.go
@@ -1,0 +1,103 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/dogmatiq/configkit"
+)
+
+// Application is an application configuration that is aware of the client it
+// was obtained from.
+type Application struct {
+	configkit.Application
+
+	// Client is the client that queried the application configuration.
+	Client *Client
+}
+
+// ApplicationObserver is notified when Dogma applications are discovered.
+type ApplicationObserver interface {
+	// ApplicationAvailable is called when an application becomes available.
+	ApplicationAvailable(*Application)
+
+	// ApplicationUnavailable is called when an application becomes unavailable.
+	ApplicationUnavailable(*Application)
+}
+
+// ApplicationObserverSet is an ApplicationObserver that publishes to other
+// observers.
+type ApplicationObserverSet struct {
+	observerSet
+}
+
+// NewApplicationObserverSet registers the given observers with a new observer
+// set and returns it.
+func NewApplicationObserverSet(observers ...ApplicationObserver) *ApplicationObserverSet {
+	s := &ApplicationObserverSet{}
+
+	for _, o := range observers {
+		s.RegisterApplicationObserver(o)
+	}
+
+	return s
+}
+
+// RegisterApplicationObserver registers o to be notified when applications
+// become available and unavailable.
+func (s *ApplicationObserverSet) RegisterApplicationObserver(o ApplicationObserver) {
+	s.register(o, func(e interface{}) {
+		o.ApplicationAvailable(e.(*Application))
+	})
+}
+
+// UnregisterApplicationObserver stops o from being notified when applications
+// become available and unavailable.
+func (s *ApplicationObserverSet) UnregisterApplicationObserver(o ApplicationObserver) {
+	s.unregister(o, func(e interface{}) {
+		o.ApplicationUnavailable(e.(*Application))
+	})
+}
+
+// ApplicationAvailable notifies the registered observers that t is available.
+func (s *ApplicationObserverSet) ApplicationAvailable(a *Application) {
+	s.add(a, func(o interface{}) {
+		o.(ApplicationObserver).ApplicationAvailable(a)
+	})
+}
+
+// ApplicationUnavailable notifies the registered observers that t is unavailable.
+func (s *ApplicationObserverSet) ApplicationUnavailable(a *Application) {
+	s.remove(a, func(o interface{}) {
+		o.(ApplicationObserver).ApplicationUnavailable(a)
+	})
+}
+
+// ApplicationTask is a function executed by an ApplicationExecutor.
+type ApplicationTask func(context.Context, *Application)
+
+// ApplicationExecutor is an ApplicationObserver that executes a function in a
+// new goroutine whenever an application becomes available.
+type ApplicationExecutor struct {
+	executor
+
+	// Task is the function to execute when an application becomes available.
+	// The context is canceled when the application becomes unavailable.
+	Task ApplicationTask
+
+	// Parent is the parent context under which the function is called.
+	// If it is nil, context.Background() is used.
+	Parent context.Context
+}
+
+// ApplicationAvailable starts a new goroutine for the given application.
+func (e *ApplicationExecutor) ApplicationAvailable(a *Application) {
+	e.start(e.Parent, a, func(ctx context.Context) {
+		e.Task(ctx, a)
+	})
+}
+
+// ApplicationUnavailable cancels the context associated with any existing
+// goroutine for the given application and waits for the goroutine to exit.
+func (e *ApplicationExecutor) ApplicationUnavailable(a *Application) {
+	e.stop(a)
+}

--- a/api/discovery/application.go
+++ b/api/discovery/application.go
@@ -58,14 +58,14 @@ func (s *ApplicationObserverSet) UnregisterApplicationObserver(o ApplicationObse
 	})
 }
 
-// ApplicationAvailable notifies the registered observers that t is available.
+// ApplicationAvailable notifies the registered observers that a is available.
 func (s *ApplicationObserverSet) ApplicationAvailable(a *Application) {
 	s.add(a, func(o interface{}) {
 		o.(ApplicationObserver).ApplicationAvailable(a)
 	})
 }
 
-// ApplicationUnavailable notifies the registered observers that t is unavailable.
+// ApplicationUnavailable notifies the registered observers that a is unavailable.
 func (s *ApplicationObserverSet) ApplicationUnavailable(a *Application) {
 	s.remove(a, func(o interface{}) {
 		o.(ApplicationObserver).ApplicationUnavailable(a)

--- a/api/discovery/application_test.go
+++ b/api/discovery/application_test.go
@@ -1,0 +1,272 @@
+package discovery_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/dogmatiq/configkit/api/discovery"
+	"github.com/dogmatiq/configkit/api/fixtures" // can't dot-import due to conflict
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ ApplicationObserver = (*ApplicationObserverSet)(nil)
+
+var _ = Describe("type ApplicationObserverSet", func() {
+	var (
+		set        *ApplicationObserverSet
+		obs1, obs2 *fixtures.ApplicationObserver
+		app1, app2 *Application
+	)
+
+	BeforeEach(func() {
+		set = &ApplicationObserverSet{}
+
+		obs1 = &fixtures.ApplicationObserver{}
+		obs2 = &fixtures.ApplicationObserver{}
+
+		app1 = &Application{}
+		app2 = &Application{}
+	})
+
+	Describe("func NewApplicationObserverSet()", func() {
+		It("returns a set containing the given observers", func() {
+			set.RegisterApplicationObserver(obs1)
+			set.RegisterApplicationObserver(obs2)
+
+			Expect(
+				NewApplicationObserverSet(obs1, obs2),
+			).To(Equal(set))
+		})
+	})
+
+	Describe("func ApplicationAvailable()", func() {
+		It("notifies the observers about the application availability", func() {
+			var observers []ApplicationObserver
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs1)
+			}
+
+			obs2.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs2)
+			}
+
+			set.RegisterApplicationObserver(obs1)
+			set.RegisterApplicationObserver(obs2)
+			set.ApplicationAvailable(app1)
+
+			Expect(observers).To(ConsistOf(obs1, obs2))
+		})
+
+		It("does nothing if the application is already available", func() {
+			set.RegisterApplicationObserver(obs1)
+			set.ApplicationAvailable(app1)
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified of the same application")
+			}
+
+			set.ApplicationAvailable(app1)
+		})
+	})
+
+	Describe("func ApplicationUnavailable()", func() {
+		It("notifies the observers about the application unavailability", func() {
+			var observers []ApplicationObserver
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs1)
+			}
+
+			obs2.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs2)
+			}
+
+			set.RegisterApplicationObserver(obs1)
+			set.RegisterApplicationObserver(obs2)
+			set.ApplicationAvailable(app1)
+			set.ApplicationUnavailable(app1)
+
+			Expect(observers).To(ConsistOf(obs1, obs2))
+		})
+
+		It("does nothing if the application is not in the registry", func() {
+			set.RegisterApplicationObserver(obs1)
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified of unknown application")
+			}
+
+			set.ApplicationUnavailable(app1)
+		})
+	})
+
+	Describe("func RegisterApplicationObserver()", func() {
+		It("notifies the observer about existing applications", func() {
+			set.ApplicationAvailable(app1)
+			set.ApplicationAvailable(app2)
+
+			var apps []*Application
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				apps = append(apps, a)
+			}
+
+			set.RegisterApplicationObserver(obs1)
+
+			Expect(apps).To(ConsistOf(app1, app2))
+		})
+
+		It("does nothing if the observer is already registered", func() {
+			set.ApplicationAvailable(app1)
+			set.RegisterApplicationObserver(obs1)
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified when registered twice")
+			}
+
+			set.RegisterApplicationObserver(obs1)
+		})
+	})
+
+	Describe("func UnregisterApplicationObserver()", func() {
+		It("synthesizes an unavailable notification for existing applications", func() {
+			set.ApplicationAvailable(app1)
+			set.ApplicationAvailable(app2)
+			set.RegisterApplicationObserver(obs1)
+
+			var apps []*Application
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				apps = append(apps, a)
+			}
+
+			set.UnregisterApplicationObserver(obs1)
+
+			Expect(apps).To(ConsistOf(app1, app2))
+		})
+
+		It("prevents the observer from receiving further notifications", func() {
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("unregistered observer unexpectedly notified")
+			}
+
+			set.RegisterApplicationObserver(obs1)
+			set.UnregisterApplicationObserver(obs1)
+			set.ApplicationAvailable(app1)
+		})
+
+		It("does nothing if the observer is not already registered", func() {
+			set.ApplicationAvailable(app1)
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified when not registered")
+			}
+
+			set.UnregisterApplicationObserver(obs1)
+		})
+	})
+})
+
+var _ ApplicationObserver = (*ApplicationExecutor)(nil)
+
+var _ = Describe("type ApplicationExecutor", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+		exec   *ApplicationExecutor
+		app    *Application
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		exec = &ApplicationExecutor{
+			Task: func(context.Context, *Application) {},
+		}
+
+		app = &Application{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func ApplicationAvailable()", func() {
+		It("starts a goroutine for the given application", func() {
+			barrier := make(chan struct{})
+
+			exec.Task = func(_ context.Context, a *Application) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				Expect(a).To(Equal(app))
+			}
+
+			exec.ApplicationAvailable(app)
+			defer exec.ApplicationUnavailable(app)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the application is already available", func() {
+			exec.ApplicationAvailable(app)
+			defer exec.ApplicationUnavailable(app)
+
+			exec.ApplicationAvailable(app)
+		})
+	})
+
+	Describe("func ApplicationUnavailable()", func() {
+		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
+			barrier := make(chan struct{})
+
+			exec.Task = func(funcCtx context.Context, a *Application) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				select {
+				case <-funcCtx.Done():
+					// ok
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			}
+
+			exec.ApplicationAvailable(app)
+			exec.ApplicationUnavailable(app)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the application is already unavailable", func() {
+			exec.ApplicationUnavailable(app)
+		})
+	})
+})

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -30,9 +30,7 @@ type ClientObserver interface {
 	ClientDisconnected(*Client)
 }
 
-// ClientObserverSet is a client observer that publishes to other observers.
-//
-// It implements both the ClientObserver and ClientPublisher interfaces.
+// ClientObserverSet is a ClientObserver that publishes to other observers.
 type ClientObserverSet struct {
 	observerSet
 }

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/api"
 	. "github.com/dogmatiq/configkit/api/discovery"
-	"github.com/dogmatiq/configkit/api/fixtures" // can't dot-import due to conflict
+	apifixtures "github.com/dogmatiq/configkit/api/fixtures" // can't dot-import due to conflict
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflict
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
@@ -23,7 +23,7 @@ var _ = Describe("type Connector", func() {
 		cancel    func()
 		listener  net.Listener
 		gserver   *grpc.Server
-		obs       *fixtures.ClientObserver
+		obs       *apifixtures.ClientObserver
 		connector *Connector
 		target    *Target
 	)
@@ -37,7 +37,7 @@ var _ = Describe("type Connector", func() {
 
 		gserver = grpc.NewServer()
 
-		obs = &fixtures.ClientObserver{
+		obs = &apifixtures.ClientObserver{
 			ClientConnectedFunc: func(c *Client) {
 				defer GinkgoRecover()
 				Fail("unexpected client connected notification")
@@ -123,7 +123,7 @@ var _ = Describe("type Connector", func() {
 
 		Context("when the server implements the config API", func() {
 			BeforeEach(func() {
-				app := &Application{
+				app := &fixtures.Application{
 					ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 						c.Identity("<app>", "<app-key>")
 					},

--- a/api/discovery/inspector.go
+++ b/api/discovery/inspector.go
@@ -1,0 +1,95 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/linger/backoff"
+)
+
+// Inspector queries connected clients and notifies an application observer
+// of the applications it has.
+type Inspector struct {
+	// Observer is notified when an application is discovered via a config API
+	// client. It must not be nil.
+	Observer ApplicationObserver
+
+	// Ignore is a predicate function that returns true if the given application
+	// should be ignored.
+	Ignore func(configkit.Application) bool
+
+	// BackoffStrategy controls how long to wait between inspection retries.
+	BackoffStrategy backoff.Strategy
+
+	// Logger is the target for log messages about inspection failures.
+	Logger logging.Logger
+}
+
+// Run queries a client in order to publish application available/unavailable
+// notifications to the observer.
+//
+// It retries until the applications are successfully discovered. After which it
+// blocks until ctx is canceled, or returns immediately if no applications were
+// found.
+func (i *Inspector) Run(ctx context.Context, c *Client) error {
+	ctr := &backoff.Counter{
+		Strategy: i.BackoffStrategy,
+	}
+
+	for {
+		err := i.list(ctx, c)
+
+		if err == nil {
+			return nil
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		logging.Log(
+			i.Logger,
+			"unable to inspect applications on '%s' target: %s",
+			c.Target.Name,
+			err,
+		)
+
+		if err := ctr.Sleep(ctx, err); err != nil {
+			return err
+		}
+	}
+}
+
+// list queries the client for applications and notifies the observer
+// accordingly.
+func (i *Inspector) list(ctx context.Context, c *Client) error {
+	configs, err := c.ListApplications(ctx)
+	if err != nil {
+		return err
+	}
+
+	empty := true
+
+	for _, cfg := range configs {
+		if i.Ignore != nil && i.Ignore(cfg) {
+			continue
+		}
+
+		empty = false
+		app := &Application{
+			Application: cfg,
+			Client:      c,
+		}
+
+		i.Observer.ApplicationAvailable(app)
+		defer i.Observer.ApplicationUnavailable(app)
+	}
+
+	if empty {
+		return nil
+	}
+
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/api/discovery/inspector_test.go
+++ b/api/discovery/inspector_test.go
@@ -1,0 +1,169 @@
+package discovery_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dogmatiq/linger/backoff"
+
+	"github.com/dogmatiq/configkit"
+	. "github.com/dogmatiq/configkit/api/discovery"
+	apifixtures "github.com/dogmatiq/configkit/api/fixtures" // can't dot-import due to conflict
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflict
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Inspector", func() {
+	var (
+		ctx        context.Context
+		cancel     func()
+		cfg1, cfg2 configkit.Application
+		obs        *apifixtures.ApplicationObserver
+		inspector  *Inspector
+		apiClient  *apifixtures.Client
+		client     *Client
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		cfg1 = configkit.FromApplication(&fixtures.Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app-1>", "<app-key-1>")
+			},
+		})
+
+		cfg2 = configkit.FromApplication(&fixtures.Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app-2>", "<app-key-2>")
+			},
+		})
+
+		obs = &apifixtures.ApplicationObserver{
+			ApplicationAvailableFunc: func(a *Application) {
+				defer GinkgoRecover()
+				Fail("unexpected application available notification")
+			},
+			ApplicationUnavailableFunc: func(a *Application) {
+				defer GinkgoRecover()
+				Fail("unexpected application unavailable notification")
+			},
+		}
+
+		inspector = &Inspector{
+			Observer:        obs,
+			BackoffStrategy: backoff.Constant(100 * time.Millisecond),
+		}
+
+		apiClient = &apifixtures.Client{
+			ListApplicationsFunc: func(context.Context) ([]configkit.Application, error) {
+				return []configkit.Application{cfg1, cfg2}, nil
+			},
+		}
+
+		client = &Client{
+			Client: apiClient,
+			Target: &Target{},
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("Run()", func() {
+		It("notifies the observer", func() {
+			runCtx, cancelRun := context.WithCancel(ctx)
+			defer cancelRun()
+
+			var available, unavailable []*Application
+
+			obs.ApplicationAvailableFunc = func(a *Application) {
+				available = append(available, a)
+
+				if len(available) == 2 {
+					cancelRun()
+				}
+			}
+
+			obs.ApplicationUnavailableFunc = func(a *Application) {
+				unavailable = append(unavailable, a)
+			}
+
+			err := inspector.Run(runCtx, client)
+			Expect(err).To(Equal(context.Canceled))
+			Expect(available).To(HaveLen(2))
+			Expect(available).To(ConsistOf(unavailable))
+			Expect(configkit.IsApplicationEqual(available[0], cfg1)).To(BeTrue())
+			Expect(configkit.IsApplicationEqual(available[1], cfg2)).To(BeTrue())
+		})
+
+		It("does not notify the observer if the application list is never obtained", func() {
+			apiClient.ListApplicationsFunc = func(context.Context) ([]configkit.Application, error) {
+				return nil, errors.New("<error>")
+			}
+
+			err := inspector.Run(ctx, client)
+			Expect(err).To(Equal(context.DeadlineExceeded))
+		})
+
+		It("does not notify the observer if the application is ignored", func() {
+			inspector.Ignore = func(a configkit.Application) bool {
+				return a.Identity().Key == "<app-key-1>"
+			}
+
+			runCtx, cancelRun := context.WithCancel(ctx)
+			defer cancelRun()
+
+			var available []*Application
+
+			obs.ApplicationAvailableFunc = func(a *Application) {
+				available = append(available, a)
+			}
+
+			obs.ApplicationUnavailableFunc = nil
+
+			err := inspector.Run(runCtx, client)
+			Expect(err).To(Equal(context.DeadlineExceeded))
+			Expect(available).To(HaveLen(1))
+			Expect(configkit.IsApplicationEqual(available[0], cfg2)).To(BeTrue())
+		})
+
+		It("returns immediately if all applications are ignored", func() {
+			inspector.Ignore = func(a configkit.Application) bool {
+				return true
+			}
+
+			err := inspector.Run(ctx, client)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("retries if the query fails", func() {
+			first := true
+
+			apiClient.ListApplicationsFunc = func(context.Context) ([]configkit.Application, error) {
+				if first {
+					first = false
+					return nil, errors.New("<error>")
+				}
+
+				return []configkit.Application{cfg1, cfg2}, nil
+			}
+
+			runCtx, cancelRun := context.WithCancel(ctx)
+			defer cancelRun()
+
+			obs.ApplicationAvailableFunc = func(a *Application) {
+				cancelRun()
+			}
+
+			obs.ApplicationUnavailableFunc = nil
+
+			err := inspector.Run(runCtx, client)
+			Expect(err).To(Equal(context.Canceled))
+		})
+	})
+})

--- a/api/discovery/target.go
+++ b/api/discovery/target.go
@@ -32,9 +32,7 @@ type TargetObserver interface {
 	TargetUnavailable(*Target)
 }
 
-// TargetObserverSet is a target observer that publishes to other observers.
-//
-// It implements both the TargetObserver and TargetPublisher interfaces.
+// TargetObserverSet is a TargetObserver that publishes to other observers.
 type TargetObserverSet struct {
 	observerSet
 }

--- a/api/fixtures/application.go
+++ b/api/fixtures/application.go
@@ -1,0 +1,34 @@
+package fixtures
+
+import (
+	"sync"
+
+	"github.com/dogmatiq/configkit/api/discovery"
+)
+
+var _ discovery.ApplicationObserver = (*ApplicationObserver)(nil)
+
+// ApplicationObserver is a mock of the discovery.ApplicationObserver interface.
+type ApplicationObserver struct {
+	m                          sync.Mutex
+	ApplicationAvailableFunc   func(*discovery.Application)
+	ApplicationUnavailableFunc func(*discovery.Application)
+}
+
+// ApplicationAvailable calls o.ApplicationAvailableFunc(a) if it is non-nil.
+func (o *ApplicationObserver) ApplicationAvailable(a *discovery.Application) {
+	if o.ApplicationAvailableFunc != nil {
+		o.m.Lock()
+		defer o.m.Unlock()
+		o.ApplicationAvailableFunc(a)
+	}
+}
+
+// ApplicationUnavailable calls o.ApplicationUnavailableFunc(a) if it is non-nil.
+func (o *ApplicationObserver) ApplicationUnavailable(a *discovery.Application) {
+	if o.ApplicationUnavailableFunc != nil {
+		o.m.Lock()
+		defer o.m.Unlock()
+		o.ApplicationUnavailableFunc(a)
+	}
+}


### PR DESCRIPTION
Based on #45, needs to be rebased after that is merged.

This PR adds:

- `ApplicationObserver`
- `ApplicationObserverSet`
- `ApplicationExecutor`

Which are all similar to those types that already exist for clients and targets.

Additionally it adds the `Inspector` type, which is a `ClientObserver` that notifies an `ApplicationObserver` of the applications found running on a specific server.