### PR TITLE
This PR moves common observer-set logic into a single embeddable type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add `discovery.TargetExecutor` and `ClientExecutor`
+
 ### Changed
 
 - **[BC]** Change the internal gRPC API namespace from `dogma.configkit.v1` to `dogma.config.v1`
+- **[BC]** `discovery.Connector` no longer implements `TargetObserver`, instead use a `TargetExecutor` to call `Connector.Run()`
 
 ## [0.3.1] - 2020-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `discovery.TargetExecutor` and `ClientExecutor`
+- Add `discovery.ApplicationObserver`, `ApplicationObserverSet` and `ApplicationExecutor`
+- Add `discovery.Inspector`
 
 ### Changed
 

--- a/api/discovery/application.go
+++ b/api/discovery/application.go
@@ -1,0 +1,176 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+
+	"github.com/dogmatiq/configkit"
+)
+
+// Application is an application configuration that is aware of the client it
+// was obtained from.
+type Application struct {
+	configkit.Application
+
+	// Client is the client that queried the application configuration.
+	Client *Client
+}
+
+// ApplicationObserver is notified when Dogma applications are discovered.
+type ApplicationObserver interface {
+	// ApplicationAvailable is called when an application becomes available.
+	ApplicationAvailable(*Application)
+
+	// ApplicationUnavailable is called when an application becomes unavailable.
+	ApplicationUnavailable(*Application)
+}
+
+// ApplicationObserverSet is an ApplicationObserver that publishes to other
+// observers.
+type ApplicationObserverSet struct {
+	m         sync.RWMutex
+	observers map[ApplicationObserver]struct{}
+	apps      map[*Application]struct{}
+}
+
+// NewApplicationObserverSet registers the given observers with a new observer
+// set and returns it.
+func NewApplicationObserverSet(observers ...ApplicationObserver) *ApplicationObserverSet {
+	s := &ApplicationObserverSet{}
+
+	for _, o := range observers {
+		s.RegisterApplicationObserver(o)
+	}
+
+	return s
+}
+
+// RegisterApplicationObserver registers o to be notified when applications
+// become available and unavailable.
+func (s *ApplicationObserverSet) RegisterApplicationObserver(o ApplicationObserver) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.observers == nil {
+		s.observers = map[ApplicationObserver]struct{}{}
+	} else if _, ok := s.observers[o]; ok {
+		return
+	}
+
+	s.observers[o] = struct{}{}
+	s.notifyOne(ApplicationObserver.ApplicationAvailable, o)
+}
+
+// UnregisterApplicationObserver stops o from being notified when applications
+// become available and unavailable.
+func (s *ApplicationObserverSet) UnregisterApplicationObserver(o ApplicationObserver) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if _, ok := s.observers[o]; !ok {
+		return
+	}
+
+	delete(s.observers, o)
+	s.notifyOne(ApplicationObserver.ApplicationUnavailable, o)
+}
+
+// ApplicationAvailable notifies the registered observers that t is available.
+func (s *ApplicationObserverSet) ApplicationAvailable(a *Application) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.apps == nil {
+		s.apps = map[*Application]struct{}{}
+	} else if _, ok := s.apps[a]; ok {
+		return
+	}
+
+	s.apps[a] = struct{}{}
+	s.notifyAll(ApplicationObserver.ApplicationAvailable, a)
+}
+
+// ApplicationUnavailable notifies the registered observers that t is unavailable.
+func (s *ApplicationObserverSet) ApplicationUnavailable(a *Application) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if _, ok := s.apps[a]; !ok {
+		return
+	}
+
+	delete(s.apps, a)
+	s.notifyAll(ApplicationObserver.ApplicationUnavailable, a)
+}
+
+// notifyAll notifies all observers about a change to one application.
+func (s *ApplicationObserverSet) notifyAll(
+	fn func(ApplicationObserver, *Application),
+	a *Application,
+) {
+	var g sync.WaitGroup
+
+	g.Add(len(s.observers))
+
+	for o := range s.observers {
+		o := o // capture loop variable
+
+		go func() {
+			defer g.Done()
+			fn(o, a)
+		}()
+	}
+
+	g.Wait()
+}
+
+// notifyOne notifies one observer about a change to all applications.
+func (s *ApplicationObserverSet) notifyOne(
+	fn func(ApplicationObserver, *Application),
+	o ApplicationObserver,
+) {
+	var g sync.WaitGroup
+
+	g.Add(len(s.apps))
+
+	for t := range s.apps {
+		t := t // capture loop variable
+
+		go func() {
+			defer g.Done()
+			fn(o, t)
+		}()
+	}
+
+	g.Wait()
+}
+
+// ApplicationTask is a function executed by an ApplicationExecutor.
+type ApplicationTask func(context.Context, *Application)
+
+// ApplicationExecutor is an ApplicationObserver that executes a function in a
+// new goroutine whenever an application becomes available.
+type ApplicationExecutor struct {
+	executor
+
+	// Task is the function to execute when an application becomes available.
+	// The context is canceled when the application becomes unavailable.
+	Task ApplicationTask
+
+	// Parent is the parent context under which the function is called.
+	// If it is nil, context.Background() is used.
+	Parent context.Context
+}
+
+// ApplicationAvailable starts a new goroutine for the given application.
+func (e *ApplicationExecutor) ApplicationAvailable(a *Application) {
+	e.start(e.Parent, a, func(ctx context.Context) {
+		e.Task(ctx, a)
+	})
+}
+
+// ApplicationUnavailable cancels the context associated with any existing
+// goroutine for the given application and waits for the goroutine to exit.
+func (e *ApplicationExecutor) ApplicationUnavailable(a *Application) {
+	e.stop(a)
+}

--- a/api/discovery/application_test.go
+++ b/api/discovery/application_test.go
@@ -1,0 +1,272 @@
+package discovery_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/dogmatiq/configkit/api/discovery"
+	"github.com/dogmatiq/configkit/api/discovery/fixtures" // can't dot-import due to conflict
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ ApplicationObserver = (*ApplicationObserverSet)(nil)
+
+var _ = Describe("type ApplicationObserverSet", func() {
+	var (
+		set        *ApplicationObserverSet
+		obs1, obs2 *fixtures.ApplicationObserver
+		app1, app2 *Application
+	)
+
+	BeforeEach(func() {
+		set = &ApplicationObserverSet{}
+
+		obs1 = &fixtures.ApplicationObserver{}
+		obs2 = &fixtures.ApplicationObserver{}
+
+		app1 = &Application{}
+		app2 = &Application{}
+	})
+
+	Describe("func NewApplicationObserverSet()", func() {
+		It("returns a set containing the given observers", func() {
+			set.RegisterApplicationObserver(obs1)
+			set.RegisterApplicationObserver(obs2)
+
+			Expect(
+				NewApplicationObserverSet(obs1, obs2),
+			).To(Equal(set))
+		})
+	})
+
+	Describe("func ApplicationAvailable()", func() {
+		It("notifies the observers about the application availability", func() {
+			var observers []ApplicationObserver
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs1)
+			}
+
+			obs2.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs2)
+			}
+
+			set.RegisterApplicationObserver(obs1)
+			set.RegisterApplicationObserver(obs2)
+			set.ApplicationAvailable(app1)
+
+			Expect(observers).To(ConsistOf(obs1, obs2))
+		})
+
+		It("does nothing if the application is already available", func() {
+			set.RegisterApplicationObserver(obs1)
+			set.ApplicationAvailable(app1)
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified of the same application")
+			}
+
+			set.ApplicationAvailable(app1)
+		})
+	})
+
+	Describe("func ApplicationUnavailable()", func() {
+		It("notifies the observers about the application unavailability", func() {
+			var observers []ApplicationObserver
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs1)
+			}
+
+			obs2.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Expect(a).To(BeIdenticalTo(app1))
+
+				observers = append(observers, obs2)
+			}
+
+			set.RegisterApplicationObserver(obs1)
+			set.RegisterApplicationObserver(obs2)
+			set.ApplicationAvailable(app1)
+			set.ApplicationUnavailable(app1)
+
+			Expect(observers).To(ConsistOf(obs1, obs2))
+		})
+
+		It("does nothing if the application is not in the registry", func() {
+			set.RegisterApplicationObserver(obs1)
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified of unknown application")
+			}
+
+			set.ApplicationUnavailable(app1)
+		})
+	})
+
+	Describe("func RegisterApplicationObserver()", func() {
+		It("notifies the observer about existing applications", func() {
+			set.ApplicationAvailable(app1)
+			set.ApplicationAvailable(app2)
+
+			var apps []*Application
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				apps = append(apps, a)
+			}
+
+			set.RegisterApplicationObserver(obs1)
+
+			Expect(apps).To(ConsistOf(app1, app2))
+		})
+
+		It("does nothing if the observer is already registered", func() {
+			set.ApplicationAvailable(app1)
+			set.RegisterApplicationObserver(obs1)
+
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified when registered twice")
+			}
+
+			set.RegisterApplicationObserver(obs1)
+		})
+	})
+
+	Describe("func UnregisterApplicationObserver()", func() {
+		It("synthesizes an unavailable notification for existing applications", func() {
+			set.ApplicationAvailable(app1)
+			set.ApplicationAvailable(app2)
+			set.RegisterApplicationObserver(obs1)
+
+			var apps []*Application
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				apps = append(apps, a)
+			}
+
+			set.UnregisterApplicationObserver(obs1)
+
+			Expect(apps).To(ConsistOf(app1, app2))
+		})
+
+		It("prevents the observer from receiving further notifications", func() {
+			obs1.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("unregistered observer unexpectedly notified")
+			}
+
+			set.RegisterApplicationObserver(obs1)
+			set.UnregisterApplicationObserver(obs1)
+			set.ApplicationAvailable(app1)
+		})
+
+		It("does nothing if the observer is not already registered", func() {
+			set.ApplicationAvailable(app1)
+
+			obs1.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				Fail("observer unexpectedly notified when not registered")
+			}
+
+			set.UnregisterApplicationObserver(obs1)
+		})
+	})
+})
+
+var _ ApplicationObserver = (*ApplicationExecutor)(nil)
+
+var _ = Describe("type ApplicationExecutor", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+		exec   *ApplicationExecutor
+		app    *Application
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		exec = &ApplicationExecutor{
+			Task: func(context.Context, *Application) {},
+		}
+
+		app = &Application{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func ApplicationAvailable()", func() {
+		It("starts a goroutine for the given application", func() {
+			barrier := make(chan struct{})
+
+			exec.Task = func(_ context.Context, a *Application) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				Expect(a).To(Equal(app))
+			}
+
+			exec.ApplicationAvailable(app)
+			defer exec.ApplicationUnavailable(app)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the application is already available", func() {
+			exec.ApplicationAvailable(app)
+			defer exec.ApplicationUnavailable(app)
+
+			exec.ApplicationAvailable(app)
+		})
+	})
+
+	Describe("func ApplicationUnavailable()", func() {
+		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
+			barrier := make(chan struct{})
+
+			exec.Task = func(funcCtx context.Context, a *Application) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				select {
+				case <-funcCtx.Done():
+					// ok
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			}
+
+			exec.ApplicationAvailable(app)
+			exec.ApplicationUnavailable(app)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the application is already unavailable", func() {
+			exec.ApplicationUnavailable(app)
+		})
+	})
+})

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -31,9 +31,7 @@ type ClientObserver interface {
 	ClientDisconnected(*Client)
 }
 
-// ClientObserverSet is a client observer that publishes to other observers.
-//
-// It implements both the ClientObserver and ClientPublisher interfaces.
+// ClientObserverSet is a ClientObserver that publishes to other observers.
 type ClientObserverSet struct {
 	m         sync.RWMutex
 	observers map[ClientObserver]struct{}

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -152,14 +152,17 @@ func (s *ClientObserverSet) notifyOne(
 	g.Wait()
 }
 
+// ClientTask is a function executed by a ClientExecutor.
+type ClientTask func(context.Context, *Client)
+
 // ClientExecutor is a ClientObserver that executes a function in a new
 // goroutine whenever a client connects.
 type ClientExecutor struct {
 	executor
 
-	// Func is the function to execute when a client connects.
+	// Task is the function to execute when a client connects.
 	// The context is canceled when the target becomes unavailable.
-	Func func(context.Context, *Client)
+	Task ClientTask
 
 	// Parent is the parent context under which the function is called.
 	// If it is nil, context.Background() is used.
@@ -169,7 +172,7 @@ type ClientExecutor struct {
 // ClientConnected starts a new goroutine for the given client.
 func (e *ClientExecutor) ClientConnected(c *Client) {
 	e.start(e.Parent, c, func(ctx context.Context) {
-		e.Func(ctx, c)
+		e.Task(ctx, c)
 	})
 }
 

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"context"
 	"sync"
 
 	"github.com/dogmatiq/configkit/api"
@@ -149,4 +150,31 @@ func (s *ClientObserverSet) notifyOne(
 	}
 
 	g.Wait()
+}
+
+// ClientExecutor is a ClientObserver that executes a function in a new
+// goroutine whenever a client connects.
+type ClientExecutor struct {
+	executor
+
+	// Func is the function to execute when a client connects.
+	// The context is canceled when the target becomes unavailable.
+	Func func(context.Context, *Client)
+
+	// Parent is the parent context under which the function is called.
+	// If it is nil, context.Background() is used.
+	Parent context.Context
+}
+
+// ClientConnected starts a new goroutine for the given client.
+func (e *ClientExecutor) ClientConnected(c *Client) {
+	e.start(e.Parent, c, func(ctx context.Context) {
+		e.Func(ctx, c)
+	})
+}
+
+// ClientDisconnected cancels the context associated with any existing goroutine
+// for the given client and waits for the goroutine to exit.
+func (e *ClientExecutor) ClientDisconnected(c *Client) {
+	e.stop(c)
 }

--- a/api/discovery/client.go
+++ b/api/discovery/client.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"context"
-	"sync"
 
 	"github.com/dogmatiq/configkit/api"
 	"google.golang.org/grpc"
@@ -33,9 +32,7 @@ type ClientObserver interface {
 
 // ClientObserverSet is a ClientObserver that publishes to other observers.
 type ClientObserverSet struct {
-	m         sync.RWMutex
-	observers map[ClientObserver]struct{}
-	clients   map[*Client]struct{}
+	observerSet
 }
 
 // NewClientObserverSet registers the given observers with a new observer set
@@ -53,101 +50,31 @@ func NewClientObserverSet(observers ...ClientObserver) *ClientObserverSet {
 // RegisterClientObserver registers o to be notified when connections to config
 // API servers are established and servered.
 func (s *ClientObserverSet) RegisterClientObserver(o ClientObserver) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if s.observers == nil {
-		s.observers = map[ClientObserver]struct{}{}
-	} else if _, ok := s.observers[o]; ok {
-		return
-	}
-
-	s.observers[o] = struct{}{}
-	s.notifyOne(ClientObserver.ClientConnected, o)
+	s.register(o, func(e interface{}) {
+		o.ClientConnected(e.(*Client))
+	})
 }
 
 // UnregisterClientObserver stops o from being notified when connections to
 // config API servers are established and servered.
 func (s *ClientObserverSet) UnregisterClientObserver(o ClientObserver) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if _, ok := s.observers[o]; !ok {
-		return
-	}
-
-	delete(s.observers, o)
-	s.notifyOne(ClientObserver.ClientDisconnected, o)
+	s.unregister(o, func(e interface{}) {
+		o.ClientDisconnected(e.(*Client))
+	})
 }
 
 // ClientConnected notifies the registered observers that c has connected.
 func (s *ClientObserverSet) ClientConnected(c *Client) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if s.clients == nil {
-		s.clients = map[*Client]struct{}{}
-	} else if _, ok := s.clients[c]; ok {
-		return
-	}
-
-	s.clients[c] = struct{}{}
-	s.notifyAll(ClientObserver.ClientConnected, c)
+	s.add(c, func(o interface{}) {
+		o.(ClientObserver).ClientConnected(c)
+	})
 }
 
 // ClientDisconnected notifies the registered observers that c has disconnected.
 func (s *ClientObserverSet) ClientDisconnected(c *Client) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if _, ok := s.clients[c]; !ok {
-		return
-	}
-
-	delete(s.clients, c)
-	s.notifyAll(ClientObserver.ClientDisconnected, c)
-}
-
-// notifyAll notifies all observers about a change to one client.
-func (s *ClientObserverSet) notifyAll(
-	fn func(ClientObserver, *Client),
-	c *Client,
-) {
-	var g sync.WaitGroup
-
-	g.Add(len(s.observers))
-
-	for o := range s.observers {
-		o := o // capture loop variable
-
-		go func() {
-			defer g.Done()
-			fn(o, c)
-		}()
-	}
-
-	g.Wait()
-}
-
-// notifyOne notifies one observer about a change to all clients.
-func (s *ClientObserverSet) notifyOne(
-	fn func(ClientObserver, *Client),
-	o ClientObserver,
-) {
-	var g sync.WaitGroup
-
-	g.Add(len(s.clients))
-
-	for c := range s.clients {
-		c := c // capture loop variable
-
-		go func() {
-			defer g.Done()
-			fn(o, c)
-		}()
-	}
-
-	g.Wait()
+	s.remove(c, func(o interface{}) {
+		o.(ClientObserver).ClientDisconnected(c)
+	})
 }
 
 // ClientTask is a function executed by a ClientExecutor.

--- a/api/discovery/client_test.go
+++ b/api/discovery/client_test.go
@@ -200,7 +200,7 @@ var _ = Describe("type ClientExecutor", func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
 
 		exec = &ClientExecutor{
-			Func: func(context.Context, *Client) {},
+			Task: func(context.Context, *Client) {},
 		}
 
 		client = &Client{}
@@ -214,7 +214,7 @@ var _ = Describe("type ClientExecutor", func() {
 		It("starts a goroutine for the given client", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(_ context.Context, c *Client) {
+			exec.Task = func(_ context.Context, c *Client) {
 				defer GinkgoRecover()
 				defer close(barrier)
 
@@ -243,7 +243,7 @@ var _ = Describe("type ClientExecutor", func() {
 		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(funcCtx context.Context, c *Client) {
+			exec.Task = func(funcCtx context.Context, c *Client) {
 				defer GinkgoRecover()
 				defer close(barrier)
 

--- a/api/discovery/connector.go
+++ b/api/discovery/connector.go
@@ -21,6 +21,10 @@ type Connector struct {
 	// If it is nil, DefaultDialer is used.
 	Dial Dialer
 
+	// Ignore is a predicate function that returns true if the given target
+	// should be ignored.
+	Ignore func(*Target) bool
+
 	// BackoffStrategy controls how long to wait between failures to dial a
 	// discovered target.
 	BackoffStrategy backoff.Strategy
@@ -34,6 +38,10 @@ type Connector struct {
 //
 // It retries until ctx is canceled.
 func (c *Connector) Watch(ctx context.Context, t *Target) error {
+	if c.Ignore != nil && c.Ignore(t) {
+		return nil
+	}
+
 	ctr := &backoff.Counter{
 		Strategy: c.BackoffStrategy,
 	}

--- a/api/discovery/connector.go
+++ b/api/discovery/connector.go
@@ -115,7 +115,7 @@ func (c *Connector) publish(
 	c.Observer.ClientConnected(client)
 	defer c.Observer.ClientDisconnected(client)
 
-	// We've successfully queried the server, so if there is an error now its a
+	// We've successfully queried the server, so if there is an error now it's a
 	// regular disconnection and we should retry immediately, therefore we reset
 	// the failure counter.
 	ctr.Reset()

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/api"
 	. "github.com/dogmatiq/configkit/api/discovery"
-	"github.com/dogmatiq/configkit/api/discovery/fixtures" // can't dot-import due to conflict
+	dfixtures "github.com/dogmatiq/configkit/api/discovery/fixtures" // can't dot-import due to conflict
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/dogma"
-	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflict
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
@@ -23,7 +23,7 @@ var _ = Describe("type Connector", func() {
 		cancel    func()
 		listener  net.Listener
 		gserver   *grpc.Server
-		obs       *fixtures.ClientObserver
+		obs       *dfixtures.ClientObserver
 		connector *Connector
 		target    *Target
 	)
@@ -37,7 +37,7 @@ var _ = Describe("type Connector", func() {
 
 		gserver = grpc.NewServer()
 
-		obs = &fixtures.ClientObserver{
+		obs = &dfixtures.ClientObserver{
 			ClientConnectedFunc: func(c *Client) {
 				defer GinkgoRecover()
 				Fail("unexpected client connected notification")
@@ -123,7 +123,7 @@ var _ = Describe("type Connector", func() {
 
 		Context("when the server implements the config API", func() {
 			BeforeEach(func() {
-				app := &Application{
+				app := &fixtures.Application{
 					ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 						c.Identity("<app>", "<app-key>")
 					},

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -108,6 +108,19 @@ var _ = Describe("type Connector", func() {
 			})
 		})
 
+		Context("when target is ignored", func() {
+			BeforeEach(func() {
+				connector.Ignore = func(t *Target) bool {
+					return t == target
+				}
+			})
+
+			It("returns immediately", func() {
+				err := connector.Watch(ctx, target)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
 		Context("when the server implements the config API", func() {
 			BeforeEach(func() {
 				app := &Application{

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -5,20 +5,17 @@ import (
 	"net"
 	"time"
 
-	"github.com/dogmatiq/dodeca/logging"
-
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/api"
 	. "github.com/dogmatiq/configkit/api/discovery"
 	"github.com/dogmatiq/configkit/api/discovery/fixtures" // can't dot-import due to conflict
+	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 )
-
-var _ TargetObserver = (*Connector)(nil)
 
 var _ = Describe("type Connector", func() {
 	var (
@@ -80,170 +77,145 @@ var _ = Describe("type Connector", func() {
 		cancel()
 	})
 
-	Context("when dialing fails", func() {
-		BeforeEach(func() {
-			listener.Close()
-			target.Options = append(target.Options, grpc.WithBlock())
+	Describe("Connect()", func() {
+		Context("when dialing fails", func() {
+			BeforeEach(func() {
+				listener.Close()
+				target.Options = append(target.Options, grpc.WithBlock())
+			})
+
+			It("does not notify the observer", func() {
+				err := connector.Watch(ctx, target)
+				Expect(err).To(Equal(context.DeadlineExceeded))
+			})
 		})
 
-		It("does not notify the observer", func() {
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
-			<-ctx.Done() // wait out the timeout
-		})
-	})
+		Context("when the server is down", func() {
+			BeforeEach(func() {
+				listener.Close()
+			})
 
-	Context("when the server is down", func() {
-		BeforeEach(func() {
-			listener.Close()
-		})
-
-		It("does not notify the observer", func() {
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
-			<-ctx.Done() // wait out the timeout
-		})
-	})
-
-	Context("when the server does not implement the config API", func() {
-		It("does not notify the observer", func() {
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
-			<-ctx.Done() // wait out the timeout
-		})
-	})
-
-	Context("when the server implements the config API", func() {
-		BeforeEach(func() {
-			app := &Application{
-				ConfigureFunc: func(c dogma.ApplicationConfigurer) {
-					c.Identity("<app>", "<app-key>")
-				},
-			}
-
-			cfg := configkit.FromApplication(app)
-			api.RegisterServer(gserver, cfg)
+			It("does not notify the observer", func() {
+				err := connector.Watch(ctx, target)
+				Expect(err).To(Equal(context.DeadlineExceeded))
+			})
 		})
 
-		It("notifies the observer", func() {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			barrier := make(chan bool)
-
-			obs.ClientConnectedFunc = func(c *Client) {
-				defer GinkgoRecover()
-
-				Expect(c.Target).To(Equal(target))
-				barrier <- true
-			}
-
-			obs.ClientDisconnectedFunc = func(c *Client) {
-				defer GinkgoRecover()
-
-				Expect(c.Target).To(Equal(target))
-				barrier <- false
-			}
-
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
-
-			select {
-			case connect := <-barrier:
-				Expect(connect).To(BeTrue())
-			case <-ctx.Done():
-				Expect(ctx.Err()).ShouldNot(HaveOccurred())
-			}
-
-			connector.TargetUnavailable(target)
-
-			select {
-			case connect := <-barrier:
-				Expect(connect).To(BeFalse())
-			case <-ctx.Done():
-				Expect(ctx.Err()).ShouldNot(HaveOccurred())
-			}
+		Context("when the server does not implement the config API", func() {
+			It("does not notify the observer", func() {
+				err := connector.Watch(ctx, target)
+				Expect(err).To(Equal(context.DeadlineExceeded))
+			})
 		})
 
-		It("connects to the server", func() {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+		Context("when the server implements the config API", func() {
+			BeforeEach(func() {
+				app := &Application{
+					ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+						c.Identity("<app>", "<app-key>")
+					},
+				}
 
-			obs.ClientConnectedFunc = func(c *Client) {
-				defer GinkgoRecover()
-				defer cancel()
+				cfg := configkit.FromApplication(app)
+				api.RegisterServer(gserver, cfg)
+			})
 
-				idents, err := c.ListApplicationIdentities(ctx)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(idents).To(ConsistOf(
-					configkit.MustNewIdentity("<app>", "<app-key>"),
-				))
-			}
+			It("notifies the observer", func() {
+				connected := make(chan struct{})
+				disconnected := make(chan struct{})
 
-			obs.ClientDisconnectedFunc = nil
+				obs.ClientConnectedFunc = func(c *Client) {
+					defer GinkgoRecover()
 
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
-			<-ctx.Done()
-		})
+					Expect(c.Target).To(Equal(target))
+					close(connected)
+				}
 
-		It("provides the underlying connection", func() {
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+				obs.ClientDisconnectedFunc = func(c *Client) {
+					defer GinkgoRecover()
 
-			obs.ClientConnectedFunc = func(c *Client) {
-				defer GinkgoRecover()
-				defer cancel()
+					Expect(c.Target).To(Equal(target))
+					close(disconnected)
+				}
 
-				client := api.NewClient(c.Connection)
-				idents, err := client.ListApplicationIdentities(ctx)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(idents).To(ConsistOf(
-					configkit.MustNewIdentity("<app>", "<app-key>"),
-				))
-			}
+				watchCtx, cancelWatch := context.WithCancel(ctx)
+				defer cancelWatch()
 
-			obs.ClientDisconnectedFunc = nil
+				go connector.Watch(watchCtx, target)
 
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
-			<-ctx.Done()
-		})
+				select {
+				case <-connected:
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
 
-		It("notifies of a disconnection if the server goes offline", func() {
-			barrier := make(chan struct{})
+				cancelWatch()
 
-			obs.ClientConnectedFunc = func(c *Client) {
-				gserver.Stop()
-			}
+				select {
+				case <-disconnected:
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			})
 
-			obs.ClientDisconnectedFunc = func(c *Client) {
-				barrier <- struct{}{}
-			}
+			It("connects to the server", func() {
+				watchCtx, cancelWatch := context.WithCancel(ctx)
+				defer cancelWatch()
 
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
+				obs.ClientConnectedFunc = func(c *Client) {
+					defer GinkgoRecover()
+					defer cancelWatch()
 
-			select {
-			case <-barrier:
-			case <-ctx.Done():
-				Expect(ctx.Err()).ShouldNot(HaveOccurred())
-			}
-		})
-	})
+					idents, err := c.ListApplicationIdentities(ctx)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(idents).To(ConsistOf(
+						configkit.MustNewIdentity("<app>", "<app-key>"),
+					))
+				}
 
-	Describe("func TargetAvailable()", func() {
-		It("does not panic if the target is already available", func() {
-			connector.TargetAvailable(target)
-			defer connector.TargetUnavailable(target)
+				obs.ClientDisconnectedFunc = nil
 
-			connector.TargetAvailable(target)
-		})
-	})
+				err := connector.Watch(watchCtx, target)
+				Expect(err).To(Equal(context.Canceled))
+			})
 
-	Describe("func TargetUnavailable()", func() {
-		It("does not panic if the target is already unavailable", func() {
-			connector.TargetUnavailable(target)
+			It("provides the underlying connection", func() {
+				watchCtx, cancelWatch := context.WithCancel(ctx)
+				defer cancelWatch()
+
+				obs.ClientConnectedFunc = func(c *Client) {
+					defer GinkgoRecover()
+					defer cancelWatch()
+
+					client := api.NewClient(c.Connection)
+					idents, err := client.ListApplicationIdentities(ctx)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(idents).To(ConsistOf(
+						configkit.MustNewIdentity("<app>", "<app-key>"),
+					))
+				}
+
+				obs.ClientDisconnectedFunc = nil
+
+				err := connector.Watch(watchCtx, target)
+				Expect(err).To(Equal(context.Canceled))
+			})
+
+			It("notifies of a disconnection if the server goes offline", func() {
+				watchCtx, cancelWatch := context.WithCancel(ctx)
+				defer cancelWatch()
+
+				obs.ClientConnectedFunc = func(c *Client) {
+					gserver.Stop()
+				}
+
+				obs.ClientDisconnectedFunc = func(c *Client) {
+					cancel()
+				}
+
+				err := connector.Watch(watchCtx, target)
+				Expect(err).To(Equal(context.Canceled))
+			})
 		})
 	})
 })

--- a/api/discovery/connector_test.go
+++ b/api/discovery/connector_test.go
@@ -77,7 +77,7 @@ var _ = Describe("type Connector", func() {
 		cancel()
 	})
 
-	Describe("Connect()", func() {
+	Describe("Watch()", func() {
 		Context("when dialing fails", func() {
 			BeforeEach(func() {
 				listener.Close()

--- a/api/discovery/executor.go
+++ b/api/discovery/executor.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// executor provides shared logic to TargetExecutor and ClientExecutor.
+// executor provides shared logic to the XXXExecutor types.
 type executor struct {
 	m     sync.Mutex
 	tasks map[interface{}]task

--- a/api/discovery/executor.go
+++ b/api/discovery/executor.go
@@ -1,0 +1,68 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+)
+
+// executor provides shared logic to TargetExecutor and ClientExecutor.
+type executor struct {
+	m     sync.Mutex
+	tasks map[interface{}]task
+}
+
+type task struct {
+	Cancel context.CancelFunc
+	Done   chan struct{}
+}
+
+func (e *executor) start(
+	parent context.Context,
+	key interface{},
+	fn func(context.Context),
+) {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	if e.tasks == nil {
+		e.tasks = map[interface{}]task{}
+	} else if _, ok := e.tasks[key]; ok {
+		return
+	}
+
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+
+	e.tasks[key] = task{
+		cancel,
+		done,
+	}
+
+	go func() {
+		defer close(done)
+		fn(ctx)
+	}()
+}
+
+func (e *executor) stop(key interface{}) {
+	if task, ok := e.remove(key); ok {
+		task.Cancel()
+		<-task.Done
+	}
+}
+
+func (e *executor) remove(key interface{}) (task, bool) {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	task, ok := e.tasks[key]
+	if ok {
+		delete(e.tasks, key)
+	}
+
+	return task, ok
+}

--- a/api/discovery/fixtures/application.go
+++ b/api/discovery/fixtures/application.go
@@ -1,0 +1,32 @@
+package fixtures
+
+import (
+	"sync"
+
+	"github.com/dogmatiq/configkit/api/discovery"
+)
+
+// ApplicationObserver is a mock of the discovery.ApplicationObserver interface.
+type ApplicationObserver struct {
+	m                          sync.Mutex
+	ApplicationAvailableFunc   func(*discovery.Application)
+	ApplicationUnavailableFunc func(*discovery.Application)
+}
+
+// ApplicationAvailable calls o.ApplicationAvailableFunc(a) if it is non-nil.
+func (o *ApplicationObserver) ApplicationAvailable(a *discovery.Application) {
+	if o.ApplicationAvailableFunc != nil {
+		o.m.Lock()
+		defer o.m.Unlock()
+		o.ApplicationAvailableFunc(a)
+	}
+}
+
+// ApplicationUnavailable calls o.ApplicationUnavailableFunc(a) if it is non-nil.
+func (o *ApplicationObserver) ApplicationUnavailable(a *discovery.Application) {
+	if o.ApplicationUnavailableFunc != nil {
+		o.m.Lock()
+		defer o.m.Unlock()
+		o.ApplicationUnavailableFunc(a)
+	}
+}

--- a/api/discovery/inspector.go
+++ b/api/discovery/inspector.go
@@ -1,0 +1,65 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/dogmatiq/configkit"
+)
+
+// Inspector queries connected clients and notifies an application observer
+// of the applications it has.
+type Inspector struct {
+	// Observer is notified when an application is discovered via a config API
+	// client. It must not be nil.
+	Observer ApplicationObserver
+
+	// Ignore is a list of application identity keys to ignore.
+	Ignore []string
+
+	apps []*Application
+}
+
+// Inspect queries a client in order to publish application
+// available/unavailable notifications to the observer.
+//
+// It blocks until ctx is canceled.
+func (i *Inspector) Inspect(ctx context.Context, c *Client) error {
+	apps, err := c.ListApplications(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		for _, a := range i.apps {
+			i.Observer.ApplicationUnavailable(a)
+		}
+	}()
+
+	for _, a := range apps {
+		if i.isIgnored(a) {
+			continue
+		}
+
+		x := &Application{
+			Application: a,
+			Client:      c,
+		}
+
+		i.apps = append(i.apps, x)
+		i.Observer.ApplicationAvailable(x)
+	}
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// isIgnored returns true if app should be ignored.
+func (i *Inspector) isIgnored(app configkit.Application) bool {
+	for _, k := range i.Ignore {
+		if k == app.Identity().Key {
+			return true
+		}
+	}
+
+	return false
+}

--- a/api/discovery/inspector.go
+++ b/api/discovery/inspector.go
@@ -13,8 +13,9 @@ type Inspector struct {
 	// client. It must not be nil.
 	Observer ApplicationObserver
 
-	// Ignore is a list of application identity keys to ignore.
-	Ignore []string
+	// Ignore is a predicate function that returns true if the given application
+	// should be ignored.
+	Ignore func(configkit.Application) bool
 
 	apps []*Application
 }
@@ -36,7 +37,7 @@ func (i *Inspector) Inspect(ctx context.Context, c *Client) error {
 	}()
 
 	for _, a := range apps {
-		if i.isIgnored(a) {
+		if i.Ignore != nil && i.Ignore(a) {
 			continue
 		}
 
@@ -51,15 +52,4 @@ func (i *Inspector) Inspect(ctx context.Context, c *Client) error {
 
 	<-ctx.Done()
 	return ctx.Err()
-}
-
-// isIgnored returns true if app should be ignored.
-func (i *Inspector) isIgnored(app configkit.Application) bool {
-	for _, k := range i.Ignore {
-		if k == app.Identity().Key {
-			return true
-		}
-	}
-
-	return false
 }

--- a/api/discovery/inspector_test.go
+++ b/api/discovery/inspector_test.go
@@ -1,0 +1,173 @@
+package discovery_test
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"google.golang.org/grpc/status"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/api"
+	. "github.com/dogmatiq/configkit/api/discovery"
+	dfixtures "github.com/dogmatiq/configkit/api/discovery/fixtures" // can't dot-import due to conflict
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var _ = Describe("type Inspector", func() {
+	var (
+		ctx       context.Context
+		cancel    func()
+		listener  net.Listener
+		gserver   *grpc.Server
+		gconn     *grpc.ClientConn
+		cfg       configkit.Application
+		obs       *dfixtures.ApplicationObserver
+		inspector *Inspector
+		client    *Client
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		var err error
+		listener, err = net.Listen("tcp", ":")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		gserver = grpc.NewServer()
+
+		app := &fixtures.Application{
+			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
+				c.Identity("<app>", "<app-key>")
+			},
+		}
+
+		cfg = configkit.FromApplication(app)
+		api.RegisterServer(gserver, cfg)
+
+		go gserver.Serve(listener)
+
+		obs = &dfixtures.ApplicationObserver{
+			ApplicationAvailableFunc: func(a *Application) {
+				defer GinkgoRecover()
+				Fail("unexpected application available notification")
+			},
+			ApplicationUnavailableFunc: func(a *Application) {
+				defer GinkgoRecover()
+				Fail("unexpected application unavailable notification")
+			},
+		}
+
+		gconn, err = grpc.DialContext(ctx, listener.Addr().String(), grpc.WithInsecure())
+		Expect(err).ShouldNot(HaveOccurred())
+		inspector = &Inspector{
+			Observer: obs,
+		}
+
+		client = &Client{
+			Client: api.NewClient(gconn),
+			Target: &Target{
+				Name: listener.Addr().String(),
+				Options: []grpc.DialOption{
+					grpc.WithInsecure(),
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		if listener != nil {
+			listener.Close()
+		}
+
+		if gserver != nil {
+			gserver.Stop()
+		}
+
+		if gconn != nil {
+			gconn.Close()
+		}
+
+		cancel()
+	})
+
+	Describe("Inspect()", func() {
+		It("notifies the observer", func() {
+			available := make(chan struct{})
+			unavailable := make(chan struct{})
+
+			obs.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+
+				Expect(a.Client).To(Equal(client))
+				close(available)
+			}
+
+			obs.ApplicationUnavailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+
+				Expect(a.Client).To(Equal(client))
+				close(unavailable)
+			}
+
+			inspectCtx, cancelInspect := context.WithCancel(ctx)
+			defer cancelInspect()
+
+			go inspector.Inspect(inspectCtx, client)
+
+			select {
+			case <-available:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+
+			cancelInspect()
+
+			select {
+			case <-unavailable:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not notify the observer if the application is ignored", func() {
+			inspector.Ignore = []string{"<app-key>"}
+
+			err := inspector.Inspect(ctx, client)
+			Expect(err).To(Equal(context.DeadlineExceeded))
+		})
+
+		It("inspects the application", func() {
+			inspectCtx, cancelInspect := context.WithCancel(ctx)
+			defer cancelInspect()
+
+			obs.ApplicationAvailableFunc = func(a *Application) {
+				defer GinkgoRecover()
+				defer cancelInspect()
+
+				Expect(configkit.IsApplicationEqual(
+					a,
+					cfg,
+				))
+			}
+
+			obs.ApplicationUnavailableFunc = nil
+
+			err := inspector.Inspect(inspectCtx, client)
+			Expect(err).To(Equal(context.Canceled))
+		})
+
+		It("returns an error if the query fails", func() {
+			gserver.Stop()
+
+			err := inspector.Inspect(ctx, client)
+			Expect(err).Should(HaveOccurred())
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+})

--- a/api/discovery/inspector_test.go
+++ b/api/discovery/inspector_test.go
@@ -136,7 +136,9 @@ var _ = Describe("type Inspector", func() {
 		})
 
 		It("does not notify the observer if the application is ignored", func() {
-			inspector.Ignore = []string{"<app-key>"}
+			inspector.Ignore = func(a configkit.Application) bool {
+				return a.Identity().Key == "<app-key>"
+			}
 
 			err := inspector.Inspect(ctx, client)
 			Expect(err).To(Equal(context.DeadlineExceeded))

--- a/api/discovery/observer.go
+++ b/api/discovery/observer.go
@@ -1,0 +1,118 @@
+package discovery
+
+import "sync"
+
+// observerSet provides shared logic to the XXXObserverSet types.
+type observerSet struct {
+	m         sync.RWMutex
+	observers map[interface{}]struct{}
+	entities  map[interface{}]struct{}
+}
+
+// register adds an observer to the set.
+func (s *observerSet) register(
+	o interface{},
+	fn func(e interface{}),
+) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.observers == nil {
+		s.observers = map[interface{}]struct{}{}
+	} else if _, ok := s.observers[o]; ok {
+		return
+	}
+
+	s.observers[o] = struct{}{}
+	s.notifyOne(fn)
+}
+
+// unregister removes an observer from the set.
+func (s *observerSet) unregister(
+	o interface{},
+	fn func(e interface{}),
+) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if _, ok := s.observers[o]; !ok {
+		return
+	}
+
+	delete(s.observers, o)
+	s.notifyOne(fn)
+}
+
+// add adds an entity to the set.
+func (s *observerSet) add(
+	e interface{},
+	fn func(o interface{}),
+) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.entities == nil {
+		s.entities = map[interface{}]struct{}{}
+	} else if _, ok := s.entities[e]; ok {
+		return
+	}
+
+	s.entities[e] = struct{}{}
+	s.notifyAll(fn)
+}
+
+// remove removes an entity from the set.
+func (s *observerSet) remove(
+	e interface{},
+	fn func(o interface{}),
+) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if _, ok := s.entities[e]; !ok {
+		return
+	}
+
+	delete(s.entities, e)
+	s.notifyAll(fn)
+}
+
+// notifyAll notifies all observers about a change to one entity.
+func (s *observerSet) notifyAll(
+	fn func(o interface{}),
+) {
+	var g sync.WaitGroup
+
+	g.Add(len(s.observers))
+
+	for o := range s.observers {
+		o := o // capture loop variable
+
+		go func() {
+			defer g.Done()
+			fn(o)
+		}()
+	}
+
+	g.Wait()
+}
+
+// notifyOne notifies one observer about a change to all entities.
+func (s *observerSet) notifyOne(
+	fn func(e interface{}),
+) {
+	var g sync.WaitGroup
+
+	g.Add(len(s.entities))
+
+	for e := range s.entities {
+		e := e // capture loop variable
+
+		go func() {
+			defer g.Done()
+			fn(e)
+		}()
+	}
+
+	g.Wait()
+}

--- a/api/discovery/target.go
+++ b/api/discovery/target.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"context"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -151,4 +152,31 @@ func (s *TargetObserverSet) notifyOne(
 	}
 
 	g.Wait()
+}
+
+// TargetExecutor is a TargetObserver that executes a function in a new
+// goroutine whenever a target becomes available.
+type TargetExecutor struct {
+	executor
+
+	// Func is the function to execute when a target becomes available.
+	// The context is canceled when the target becomes unavailable.
+	Func func(context.Context, *Target)
+
+	// Parent is the parent context under which the function is called.
+	// If it is nil, context.Background() is used.
+	Parent context.Context
+}
+
+// TargetAvailable starts a new goroutine for the given target.
+func (e *TargetExecutor) TargetAvailable(t *Target) {
+	e.start(e.Parent, t, func(ctx context.Context) {
+		e.Func(ctx, t)
+	})
+}
+
+// TargetUnavailable cancels the context associated with any existing goroutine
+// for the given target and waits for the goroutine to exit.
+func (e *TargetExecutor) TargetUnavailable(t *Target) {
+	e.stop(t)
 }

--- a/api/discovery/target.go
+++ b/api/discovery/target.go
@@ -154,14 +154,17 @@ func (s *TargetObserverSet) notifyOne(
 	g.Wait()
 }
 
+// TargetTask is a function executed by a TargetExecutor.
+type TargetTask func(context.Context, *Target)
+
 // TargetExecutor is a TargetObserver that executes a function in a new
 // goroutine whenever a target becomes available.
 type TargetExecutor struct {
 	executor
 
-	// Func is the function to execute when a target becomes available.
+	// Task is the function to execute when a target becomes available.
 	// The context is canceled when the target becomes unavailable.
-	Func func(context.Context, *Target)
+	Task TargetTask
 
 	// Parent is the parent context under which the function is called.
 	// If it is nil, context.Background() is used.
@@ -171,7 +174,7 @@ type TargetExecutor struct {
 // TargetAvailable starts a new goroutine for the given target.
 func (e *TargetExecutor) TargetAvailable(t *Target) {
 	e.start(e.Parent, t, func(ctx context.Context) {
-		e.Func(ctx, t)
+		e.Task(ctx, t)
 	})
 }
 

--- a/api/discovery/target.go
+++ b/api/discovery/target.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"context"
-	"sync"
 
 	"google.golang.org/grpc"
 )
@@ -35,9 +34,7 @@ type TargetObserver interface {
 
 // TargetObserverSet is a TargetObserver that publishes to other observers.
 type TargetObserverSet struct {
-	m         sync.RWMutex
-	observers map[TargetObserver]struct{}
-	targets   map[*Target]struct{}
+	observerSet
 }
 
 // NewTargetObserverSet registers the given observers with a new observer set
@@ -55,101 +52,31 @@ func NewTargetObserverSet(observers ...TargetObserver) *TargetObserverSet {
 // RegisterTargetObserver registers o to be notified when targets become
 // available and unavailable.
 func (s *TargetObserverSet) RegisterTargetObserver(o TargetObserver) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if s.observers == nil {
-		s.observers = map[TargetObserver]struct{}{}
-	} else if _, ok := s.observers[o]; ok {
-		return
-	}
-
-	s.observers[o] = struct{}{}
-	s.notifyOne(TargetObserver.TargetAvailable, o)
+	s.register(o, func(e interface{}) {
+		o.TargetAvailable(e.(*Target))
+	})
 }
 
 // UnregisterTargetObserver stops o from being notified when targets become
 // available and unavailable.
 func (s *TargetObserverSet) UnregisterTargetObserver(o TargetObserver) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if _, ok := s.observers[o]; !ok {
-		return
-	}
-
-	delete(s.observers, o)
-	s.notifyOne(TargetObserver.TargetUnavailable, o)
+	s.unregister(o, func(e interface{}) {
+		o.TargetUnavailable(e.(*Target))
+	})
 }
 
 // TargetAvailable notifies the registered observers that t is available.
 func (s *TargetObserverSet) TargetAvailable(t *Target) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if s.targets == nil {
-		s.targets = map[*Target]struct{}{}
-	} else if _, ok := s.targets[t]; ok {
-		return
-	}
-
-	s.targets[t] = struct{}{}
-	s.notifyAll(TargetObserver.TargetAvailable, t)
+	s.add(t, func(o interface{}) {
+		o.(TargetObserver).TargetAvailable(t)
+	})
 }
 
 // TargetUnavailable notifies the registered observers that t is unavailable.
 func (s *TargetObserverSet) TargetUnavailable(t *Target) {
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	if _, ok := s.targets[t]; !ok {
-		return
-	}
-
-	delete(s.targets, t)
-	s.notifyAll(TargetObserver.TargetUnavailable, t)
-}
-
-// notifyAll notifies all observers about a change to one target.
-func (s *TargetObserverSet) notifyAll(
-	fn func(TargetObserver, *Target),
-	t *Target,
-) {
-	var g sync.WaitGroup
-
-	g.Add(len(s.observers))
-
-	for o := range s.observers {
-		o := o // capture loop variable
-
-		go func() {
-			defer g.Done()
-			fn(o, t)
-		}()
-	}
-
-	g.Wait()
-}
-
-// notifyOne notifies one observer about a change to all targets.
-func (s *TargetObserverSet) notifyOne(
-	fn func(TargetObserver, *Target),
-	o TargetObserver,
-) {
-	var g sync.WaitGroup
-
-	g.Add(len(s.targets))
-
-	for t := range s.targets {
-		t := t // capture loop variable
-
-		go func() {
-			defer g.Done()
-			fn(o, t)
-		}()
-	}
-
-	g.Wait()
+	s.remove(t, func(o interface{}) {
+		o.(TargetObserver).TargetUnavailable(t)
+	})
 }
 
 // TargetTask is a function executed by a TargetExecutor.

--- a/api/discovery/target.go
+++ b/api/discovery/target.go
@@ -33,9 +33,7 @@ type TargetObserver interface {
 	TargetUnavailable(*Target)
 }
 
-// TargetObserverSet is a target observer that publishes to other observers.
-//
-// It implements both the TargetObserver and TargetPublisher interfaces.
+// TargetObserverSet is a TargetObserver that publishes to other observers.
 type TargetObserverSet struct {
 	m         sync.RWMutex
 	observers map[TargetObserver]struct{}

--- a/api/discovery/target_test.go
+++ b/api/discovery/target_test.go
@@ -1,6 +1,9 @@
 package discovery_test
 
 import (
+	"context"
+	"time"
+
 	. "github.com/dogmatiq/configkit/api/discovery"
 	"github.com/dogmatiq/configkit/api/discovery/fixtures" // can't dot-import due to conflict
 	. "github.com/onsi/ginkgo"
@@ -179,6 +182,91 @@ var _ = Describe("type TargetObserverSet", func() {
 			}
 
 			set.UnregisterTargetObserver(obs1)
+		})
+	})
+})
+
+var _ TargetObserver = (*TargetExecutor)(nil)
+
+var _ = Describe("type TargetExecutor", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+		exec   *TargetExecutor
+		target *Target
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
+
+		exec = &TargetExecutor{
+			Func: func(context.Context, *Target) {},
+		}
+
+		target = &Target{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func TargetAvailable()", func() {
+		It("starts a goroutine for the given target", func() {
+			barrier := make(chan struct{})
+
+			exec.Func = func(_ context.Context, t *Target) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				Expect(t).To(Equal(target))
+			}
+
+			exec.TargetAvailable(target)
+			defer exec.TargetUnavailable(target)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the target is already available", func() {
+			exec.TargetAvailable(target)
+			defer exec.TargetUnavailable(target)
+
+			exec.TargetAvailable(target)
+		})
+	})
+
+	Describe("func TargetUnavailable()", func() {
+		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
+			barrier := make(chan struct{})
+
+			exec.Func = func(funcCtx context.Context, t *Target) {
+				defer GinkgoRecover()
+				defer close(barrier)
+
+				select {
+				case <-funcCtx.Done():
+					// ok
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			}
+
+			exec.TargetAvailable(target)
+			exec.TargetUnavailable(target)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+		})
+
+		It("does not panic if the target is already unavailable", func() {
+			exec.TargetUnavailable(target)
 		})
 	})
 })

--- a/api/discovery/target_test.go
+++ b/api/discovery/target_test.go
@@ -200,7 +200,7 @@ var _ = Describe("type TargetExecutor", func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 250*time.Millisecond)
 
 		exec = &TargetExecutor{
-			Func: func(context.Context, *Target) {},
+			Task: func(context.Context, *Target) {},
 		}
 
 		target = &Target{}
@@ -214,7 +214,7 @@ var _ = Describe("type TargetExecutor", func() {
 		It("starts a goroutine for the given target", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(_ context.Context, t *Target) {
+			exec.Task = func(_ context.Context, t *Target) {
 				defer GinkgoRecover()
 				defer close(barrier)
 
@@ -243,7 +243,7 @@ var _ = Describe("type TargetExecutor", func() {
 		It("cancels the context associated with the goroutine and waits for the function to finish", func() {
 			barrier := make(chan struct{})
 
-			exec.Func = func(funcCtx context.Context, t *Target) {
+			exec.Task = func(funcCtx context.Context, t *Target) {
 				defer GinkgoRecover()
 				defer close(barrier)
 


### PR DESCRIPTION
Based on #48, needs to be rebased after that is merged.