### PR TITLE
Add `IsEqualSetT()` and `IsEqualSetN()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `message.IsEqualSetN()` and `IsEqualSetT()`
+
 ## [0.7.0] - 2020-03-15
 
 ### Added

--- a/message/name.go
+++ b/message/name.go
@@ -25,6 +25,14 @@ type NameCollection interface {
 	Range(fn func(Name) bool) bool
 }
 
+// IsEqualSetN returns true if a and b are equal.
+//
+// That is, it returns true if and only if every element of a is an element of
+// b, and vice-versa.
+func IsEqualSetN(a, b NameCollection) bool {
+	return IsSubsetN(a, b) && IsSubsetN(b, a)
+}
+
 // IsIntersectingN returns true if a and b are intersecting.
 //
 // That is, it returns true if a and b contain any of the same names.

--- a/message/name_test.go
+++ b/message/name_test.go
@@ -7,6 +7,26 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("func IsEqualSetN()", func() {
+	It("returns true for identical sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsEqualSetN(a, b)).To(BeTrue())
+	})
+
+	It("returns false for disjoint sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageC1, fixtures.MessageD1)
+		Expect(IsEqualSetN(a, b)).To(BeFalse())
+	})
+
+	It("returns false for intersecting sets", func() {
+		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := NamesOf(fixtures.MessageB1, fixtures.MessageC1)
+		Expect(IsEqualSetN(a, b)).To(BeFalse())
+	})
+})
+
 var _ = Describe("func IsIntersectingN()", func() {
 	It("returns true for identical sets", func() {
 		a := NamesOf(fixtures.MessageA1, fixtures.MessageB1)

--- a/message/type.go
+++ b/message/type.go
@@ -24,6 +24,14 @@ type TypeCollection interface {
 	Range(fn func(Type) bool) bool
 }
 
+// IsEqualSetT returns true if a and b are equal.
+//
+// That is, it returns true if and only if every element of a is an element of
+// b, and vice-versa.
+func IsEqualSetT(a, b TypeCollection) bool {
+	return IsSubsetT(a, b) && IsSubsetT(b, a)
+}
+
 // IsIntersectingT returns true if a and b are intersecting.
 //
 // That is, it returns true if a and b contain any of the same types.

--- a/message/type_test.go
+++ b/message/type_test.go
@@ -9,6 +9,26 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("func IsEqualT()", func() {
+	It("returns true for identical sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		Expect(IsEqualSetT(a, b)).To(BeTrue())
+	})
+
+	It("returns false for disjoint sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageC1, fixtures.MessageD1)
+		Expect(IsEqualSetT(a, b)).To(BeFalse())
+	})
+
+	It("returns false for intersecting sets", func() {
+		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)
+		b := TypesOf(fixtures.MessageB1, fixtures.MessageC1)
+		Expect(IsEqualSetT(a, b)).To(BeFalse())
+	})
+})
+
 var _ = Describe("func IsIntersectingT()", func() {
 	It("returns true for identical sets", func() {
 		a := TypesOf(fixtures.MessageA1, fixtures.MessageB1)


### PR DESCRIPTION
This PR adds two new set-equality functions for the `TypeCollection` and `NameCollection` types.

I used the name `IsEqualSetX()` as opposed to just `IsEqual()` because there are implementations of both of these interfaces that are maps, but the set comparison functions only take into account the keys, not the values, so they don't need to be "equal" to be an "equal set of types/names".

True equality can be checked using the existing `IsEqual()` methods on the concrete implementations of these interfaces.