### PR TITLE
Allow retrieval of message names/types from handler sets.

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -78,8 +78,8 @@ func (m EntityMessageNames) All() message.NameRoles {
 	return roles
 }
 
-// Foreign returns the subset of message names used by the entity that must be
-// communicated beyond the scope of that entity.
+// Foreign returns the subset of message names used by a set of entities that
+// must be communicated beyond the scope of those entities.
 //
 // This includes:
 //  - commands that are produced by the entity, but consumed elsewhere
@@ -158,8 +158,8 @@ func (m EntityMessageTypes) IsEqual(o EntityMessageTypes) bool {
 		m.Consumed.IsEqual(o.Consumed)
 }
 
-// Foreign returns the subset of message types used by an entity that must be
-// communicated beyond the scope of that entity.
+// Foreign returns the subset of message types used by a set of entities that
+// must be communicated beyond the scope of those entities.
 //
 // This includes:
 //  - commands that are produced by this entity, but consumed elsewhere

--- a/go.sum
+++ b/go.sum
@@ -90,10 +90,6 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=
-google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.29.0 h1:2pJjwYOdkZ9HlN4sWRYBg9ttH5bCOlsueaM+b/oYjwo=
-google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/handlerset.go
+++ b/handlerset.go
@@ -89,6 +89,28 @@ func (s HandlerSet) ProducersOf(n message.Name) HandlerSet {
 	})
 }
 
+// MessageNames returns information about the messages used all handlers in s.
+func (s HandlerSet) MessageNames() EntityMessageNames {
+	names := EntityMessageNames{
+		Produced: message.NameRoles{},
+		Consumed: message.NameRoles{},
+	}
+
+	for _, h := range s {
+		m := h.MessageNames()
+
+		for n, r := range m.Consumed {
+			names.Consumed[n] = r
+		}
+
+		for n, r := range m.Produced {
+			names.Produced[n] = r
+		}
+	}
+
+	return names
+}
+
 // IsEqual returns true if o contains the same handlers as s.
 func (s HandlerSet) IsEqual(o HandlerSet) bool {
 	if len(s) != len(o) {
@@ -378,6 +400,28 @@ func (s RichHandlerSet) ProducersOf(t message.Type) RichHandlerSet {
 	}
 
 	return subset
+}
+
+// MessageTypes returns information about the messages used all handlers in s.
+func (s RichHandlerSet) MessageTypes() EntityMessageTypes {
+	types := EntityMessageTypes{
+		Produced: message.TypeRoles{},
+		Consumed: message.TypeRoles{},
+	}
+
+	for _, h := range s {
+		m := h.MessageTypes()
+
+		for n, t := range m.Consumed {
+			types.Consumed[n] = t
+		}
+
+		for n, t := range m.Produced {
+			types.Produced[n] = t
+		}
+	}
+
+	return types
 }
 
 // IsEqual returns true if o contains the same handlers as s.

--- a/handlerset_test.go
+++ b/handlerset_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/dogmatiq/configkit"
 	cfixtures "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/dogma/fixtures" // can't dot-import due to conflicts
 	. "github.com/onsi/ginkgo"
@@ -169,6 +170,27 @@ var _ = Describe("type HandlerSet", func() {
 			subset := set.ProducersOf(cfixtures.MessageETypeName)
 			Expect(subset).To(HaveLen(1))
 			Expect(set.Has(aggregate)).To(BeTrue())
+		})
+	})
+
+	Describe("func MessageNames()", func() {
+		BeforeEach(func() {
+			set.Add(aggregate)
+			set.Add(projection)
+		})
+
+		It("returns the messages used by the handlers in the set", func() {
+			Expect(set.MessageNames()).To(Equal(
+				EntityMessageNames{
+					Produced: message.NameRoles{
+						cfixtures.MessageETypeName: message.EventRole,
+					},
+					Consumed: message.NameRoles{
+						cfixtures.MessageCTypeName: message.CommandRole,
+						cfixtures.MessageETypeName: message.EventRole,
+					},
+				},
+			))
 		})
 	})
 
@@ -669,6 +691,27 @@ var _ = Describe("type RichHandlerSet", func() {
 			subset := set.ProducersOf(cfixtures.MessageEType)
 			Expect(subset).To(HaveLen(1))
 			Expect(set.Has(aggregate)).To(BeTrue())
+		})
+	})
+
+	Describe("func MessageTypes()", func() {
+		BeforeEach(func() {
+			set.Add(aggregate)
+			set.Add(projection)
+		})
+
+		It("returns the messages used by the handlers in the set", func() {
+			Expect(set.MessageTypes()).To(Equal(
+				EntityMessageTypes{
+					Produced: message.TypeRoles{
+						cfixtures.MessageEType: message.EventRole,
+					},
+					Consumed: message.TypeRoles{
+						cfixtures.MessageCType: message.CommandRole,
+						cfixtures.MessageEType: message.EventRole,
+					},
+				},
+			))
 		})
 	})
 


### PR DESCRIPTION
This PR adds `HandlerSet.MethodNames()` and `RichHandlerSet.MethodTypes()` methods to obtain sets of messages used by sets of handlers.