### PR TITLE
Add support for analysing aggregate handlers.

### DIFF
--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -58,12 +58,10 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 											"Consumed": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
 											}),
 											"Produced": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageC{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageF{}): Equal(message.EventRole),
 											}),
 										}),
 										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
@@ -121,13 +119,9 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 										"MessageNamesValue": MatchAllFields(Fields{
 											"Consumed": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
 											}),
 											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageF{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageB{}): Equal(message.EventRole),
 											}),
 										}),
 										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
@@ -149,14 +143,10 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 										),
 										"MessageNamesValue": MatchAllFields(Fields{
 											"Consumed": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageG{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageH{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageI{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
 											}),
 											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageJ{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageK{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageL{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
 											}),
 										}),
 										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
@@ -242,11 +232,9 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 										"MessageNamesValue": MatchAllFields(Fields{
 											"Consumed": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
 											}),
 											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageB{}): Equal(message.EventRole),
 											}),
 										}),
 										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -2,9 +2,9 @@ package static_test
 
 import (
 	"github.com/dogmatiq/configkit"
+	cfixtures "github.com/dogmatiq/configkit/fixtures"
 	"github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/configkit/static"
-	"github.com/dogmatiq/dogma/fixtures"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/tools/go/packages"
@@ -40,22 +40,19 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 				),
 			)
 			Expect(a.HandlerType()).To(Equal(configkit.AggregateHandlerType))
-			Expect(
-				a.MessageNames().Consumed.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageA{}): message.CommandRole,
-						message.NameOf(fixtures.MessageB{}): message.CommandRole,
+
+			Expect(a.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
+						cfixtures.MessageBTypeName: message.CommandRole,
 					},
-				),
-			).To(BeTrue())
-			Expect(
-				a.MessageNames().Produced.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageC{}): message.EventRole,
-						message.NameOf(fixtures.MessageD{}): message.EventRole,
+					Produced: message.NameRoles{
+						cfixtures.MessageCTypeName: message.EventRole,
+						cfixtures.MessageDTypeName: message.EventRole,
 					},
-				),
-			).To(BeTrue())
+				},
+			))
 		})
 	})
 
@@ -88,20 +85,16 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 				),
 			)
 			Expect(a1.HandlerType()).To(Equal(configkit.AggregateHandlerType))
-			Expect(
-				a1.MessageNames().Consumed.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageA{}): message.CommandRole,
+			Expect(a1.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
 					},
-				),
-			).To(BeTrue())
-			Expect(
-				a1.MessageNames().Produced.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageB{}): message.EventRole,
+					Produced: message.NameRoles{
+						cfixtures.MessageBTypeName: message.EventRole,
 					},
-				),
-			).To(BeTrue())
+				},
+			))
 
 			a2 := apps[0].Handlers().Aggregates()[1]
 			Expect(a2.Identity()).To(
@@ -118,20 +111,16 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 				),
 			)
 			Expect(a2.HandlerType()).To(Equal(configkit.AggregateHandlerType))
-			Expect(
-				a2.MessageNames().Consumed.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageC{}): message.CommandRole,
+			Expect(a2.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageCTypeName: message.CommandRole,
 					},
-				),
-			).To(BeTrue())
-			Expect(
-				a2.MessageNames().Produced.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageD{}): message.EventRole,
+					Produced: message.NameRoles{
+						cfixtures.MessageDTypeName: message.EventRole,
 					},
-				),
-			).To(BeTrue())
+				},
+			))
 		})
 	})
 
@@ -180,20 +169,16 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 				),
 			)
 			Expect(a.HandlerType()).To(Equal(configkit.AggregateHandlerType))
-			Expect(
-				a.MessageNames().Consumed.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageA{}): message.CommandRole,
+			Expect(a.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
 					},
-				),
-			).To(BeTrue())
-			Expect(
-				a.MessageNames().Produced.IsEqual(
-					message.NameRoles{
-						message.NameOf(fixtures.MessageB{}): message.EventRole,
+					Produced: message.NameRoles{
+						cfixtures.MessageBTypeName: message.EventRole,
 					},
-				),
-			).To(BeTrue())
+				},
+			))
 		})
 	})
 })

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -25,51 +25,38 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 
 			apps := FromPackages(pkgs)
 
-			Expect(apps).To(
-				ConsistOf(
-					PointTo(
-						MatchAllFields(Fields{
-							"IdentityValue": Equal(
-								configkit.Identity{
-									Name: "<single-aggregate-app>",
-									Key:  "3bc3849b-abe0-4c4e-9db4-e48dc28c9a26",
-								},
-							),
-							"TypeNameValue": Equal(
-								"github.com/dogmatiq/configkit/static/testdata/aggregates/single-aggregate-app.App",
-							),
-							"MessageNamesValue": Equal(configkit.EntityMessageNames{}),
-							"HandlersValue": MatchAllKeys(Keys{
-								configkit.Identity{
-									Name: "<aggregate>",
-									Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
-								}: PointTo(
-									MatchAllFields(Fields{
-										"IdentityValue": Equal(
-											configkit.Identity{
-												Name: "<aggregate>",
-												Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
-											},
-										),
-										"TypeNameValue": Equal(
-											"github.com/dogmatiq/configkit/static/testdata/aggregates/single-aggregate-app.AggregateHandler",
-										),
-										"MessageNamesValue": MatchAllFields(Fields{
-											"Consumed": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
-												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
-											}),
-											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageC{}): Equal(message.EventRole),
-												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
-											}),
-										}),
-										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
-									}),
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers()).To(
+				MatchAllKeys(
+					Keys{
+						configkit.Identity{
+							Name: "<aggregate>",
+							Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
+						}: PointTo(
+							MatchAllFields(Fields{
+								"IdentityValue": Equal(
+									configkit.Identity{
+										Name: "<aggregate>",
+										Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
+									},
 								),
+								"TypeNameValue": Equal(
+									"github.com/dogmatiq/configkit/static/testdata/aggregates/single-aggregate-app.AggregateHandler",
+								),
+								"MessageNamesValue": MatchAllFields(Fields{
+									"Consumed": MatchAllKeys(Keys{
+										message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
+										message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
+									}),
+									"Produced": MatchAllKeys(Keys{
+										message.NameOf(fixtures.MessageC{}): Equal(message.EventRole),
+										message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
+									}),
+								}),
+								"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
 							}),
-						}),
-					),
+						),
+					},
 				),
 			)
 		})
@@ -87,74 +74,49 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 
 			apps := FromPackages(pkgs)
 
-			Expect(apps).To(
-				ConsistOf(
-					PointTo(
-						MatchAllFields(Fields{
-							"IdentityValue": Equal(
-								configkit.Identity{
-									Name: "<multiple-aggregate-app>",
-									Key:  "66abab58-e0cd-4d50-90c2-b0bd093ea2ba",
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers()).To(
+				Equal(
+					configkit.HandlerSet{
+						configkit.Identity{
+							Name: "<first-aggregate>",
+							Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
+						}: &entity.Handler{
+							IdentityValue: configkit.Identity{
+								Name: "<first-aggregate>",
+								Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
+							},
+							TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.FirstAggregateHandler",
+							MessageNamesValue: configkit.EntityMessageNames{
+								Consumed: message.NameRoles{
+									message.NameOf(fixtures.MessageA{}): message.CommandRole,
 								},
-							),
-							"TypeNameValue": Equal(
-								"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.App",
-							),
-							"MessageNamesValue": Equal(configkit.EntityMessageNames{}),
-							"HandlersValue": MatchAllKeys(Keys{
-								configkit.Identity{
-									Name: "<first-aggregate>",
-									Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
-								}: PointTo(
-									MatchAllFields(Fields{
-										"IdentityValue": Equal(
-											configkit.Identity{
-												Name: "<first-aggregate>",
-												Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
-											},
-										),
-										"TypeNameValue": Equal(
-											"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.FirstAggregateHandler",
-										),
-										"MessageNamesValue": MatchAllFields(Fields{
-											"Consumed": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
-											}),
-											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageB{}): Equal(message.EventRole),
-											}),
-										}),
-										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
-									}),
-								),
-								configkit.Identity{
-									Name: "<second-aggregate>",
-									Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
-								}: PointTo(
-									MatchAllFields(Fields{
-										"IdentityValue": Equal(
-											configkit.Identity{
-												Name: "<second-aggregate>",
-												Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
-											},
-										),
-										"TypeNameValue": Equal(
-											"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.SecondAggregateHandler",
-										),
-										"MessageNamesValue": MatchAllFields(Fields{
-											"Consumed": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
-											}),
-											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
-											}),
-										}),
-										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
-									}),
-								),
-							}),
-						}),
-					),
+								Produced: message.NameRoles{
+									message.NameOf(fixtures.MessageB{}): message.EventRole,
+								},
+							},
+							HandlerTypeValue: configkit.AggregateHandlerType,
+						},
+						configkit.Identity{
+							Name: "<second-aggregate>",
+							Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
+						}: &entity.Handler{
+							IdentityValue: configkit.Identity{
+								Name: "<second-aggregate>",
+								Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
+							},
+							TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.SecondAggregateHandler",
+							MessageNamesValue: configkit.EntityMessageNames{
+								Consumed: message.NameRoles{
+									message.NameOf(fixtures.MessageC{}): message.CommandRole,
+								},
+								Produced: message.NameRoles{
+									message.NameOf(fixtures.MessageD{}): message.EventRole,
+								},
+							},
+							HandlerTypeValue: configkit.AggregateHandlerType,
+						},
+					},
 				),
 			)
 		})
@@ -171,20 +133,9 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
-						Name: "<nil-aggregate-app>",
-						Key:  "250738eb-7728-4414-a850-1afefb04dbb4",
-					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/aggregates/nil-aggregate-app.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
-				},
-			))
+
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 
@@ -200,49 +151,30 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 
 			apps := FromPackages(pkgs)
 
-			Expect(apps).To(
-				ConsistOf(
-					PointTo(
-						MatchAllFields(Fields{
-							"IdentityValue": Equal(
-								configkit.Identity{
-									Name: "<nil-message-aggregate-app>",
-									Key:  "77199eb1-c893-4151-aab8-5088f6db4ea6",
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers()).To(
+				Equal(
+					configkit.HandlerSet{
+						configkit.Identity{
+							Name: "<nil-message-aggregate>",
+							Key:  "99271492-1ec3-475f-b154-3e69cda11155",
+						}: &entity.Handler{
+							IdentityValue: configkit.Identity{
+								Name: "<nil-message-aggregate>",
+								Key:  "99271492-1ec3-475f-b154-3e69cda11155",
+							},
+							TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/aggregates/nil-message-aggregate-app.AggregateHandler",
+							MessageNamesValue: configkit.EntityMessageNames{
+								Consumed: message.NameRoles{
+									message.NameOf(fixtures.MessageA{}): message.CommandRole,
 								},
-							),
-							"TypeNameValue": Equal(
-								"github.com/dogmatiq/configkit/static/testdata/aggregates/nil-message-aggregate-app.App",
-							),
-							"MessageNamesValue": Equal(configkit.EntityMessageNames{}),
-							"HandlersValue": MatchAllKeys(Keys{
-								configkit.Identity{
-									Name: "<nil-message-aggregate>",
-									Key:  "99271492-1ec3-475f-b154-3e69cda11155",
-								}: PointTo(
-									MatchAllFields(Fields{
-										"IdentityValue": Equal(
-											configkit.Identity{
-												Name: "<nil-message-aggregate>",
-												Key:  "99271492-1ec3-475f-b154-3e69cda11155",
-											},
-										),
-										"TypeNameValue": Equal(
-											"github.com/dogmatiq/configkit/static/testdata/aggregates/nil-message-aggregate-app.AggregateHandler",
-										),
-										"MessageNamesValue": MatchAllFields(Fields{
-											"Consumed": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
-											}),
-											"Produced": MatchAllKeys(Keys{
-												message.NameOf(fixtures.MessageB{}): Equal(message.EventRole),
-											}),
-										}),
-										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
-									}),
-								),
-							}),
-						}),
-					),
+								Produced: message.NameRoles{
+									message.NameOf(fixtures.MessageB{}): message.EventRole,
+								},
+							},
+							HandlerTypeValue: configkit.AggregateHandlerType,
+						},
+					},
 				),
 			)
 		})

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -54,12 +54,12 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 											"github.com/dogmatiq/configkit/static/testdata/aggregates/single-aggregate-app.AggregateHandler",
 										),
 										"MessageNamesValue": MatchAllFields(Fields{
-											"Produced": MatchAllKeys(Keys{
+											"Consumed": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
 											}),
-											"Consumed": MatchAllKeys(Keys{
+											"Produced": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageF{}): Equal(message.EventRole),
@@ -118,12 +118,12 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 											"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.FirstAggregateHandler",
 										),
 										"MessageNamesValue": MatchAllFields(Fields{
-											"Produced": MatchAllKeys(Keys{
+											"Consumed": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
 											}),
-											"Consumed": MatchAllKeys(Keys{
+											"Produced": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageF{}): Equal(message.EventRole),
@@ -147,12 +147,12 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 											"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.SecondAggregateHandler",
 										),
 										"MessageNamesValue": MatchAllFields(Fields{
-											"Produced": MatchAllKeys(Keys{
+											"Consumed": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageG{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageH{}): Equal(message.CommandRole),
 												message.NameOf(fixtures.MessageI{}): Equal(message.CommandRole),
 											}),
-											"Consumed": MatchAllKeys(Keys{
+											"Produced": MatchAllKeys(Keys{
 												message.NameOf(fixtures.MessageJ{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageK{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageL{}): Equal(message.EventRole),

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -1,0 +1,171 @@
+package static_test
+
+import (
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
+	. "github.com/dogmatiq/configkit/static"
+	"github.com/dogmatiq/dogma/fixtures"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"golang.org/x/tools/go/packages"
+)
+
+var _ = Describe("func FromPackages() (aggregate analysis)", func() {
+	When("the application contains a single aggregate handler", func() {
+		It("returns the aggregate handler configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/aggregates/single-aggregate-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+
+			Expect(apps).To(
+				ConsistOf(
+					PointTo(
+						MatchAllFields(Fields{
+							"IdentityValue": Equal(
+								configkit.Identity{
+									Name: "<single-aggregate-app>",
+									Key:  "3bc3849b-abe0-4c4e-9db4-e48dc28c9a26",
+								},
+							),
+							"TypeNameValue": Equal(
+								"github.com/dogmatiq/configkit/static/testdata/aggregates/single-aggregate-app.App",
+							),
+							"MessageNamesValue": Equal(configkit.EntityMessageNames{}),
+							"HandlersValue": MatchAllKeys(Keys{
+								configkit.Identity{
+									Name: "<aggregate>",
+									Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
+								}: PointTo(
+									MatchAllFields(Fields{
+										"IdentityValue": Equal(
+											configkit.Identity{
+												Name: "<aggregate>",
+												Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
+											},
+										),
+										"TypeNameValue": Equal(
+											"github.com/dogmatiq/configkit/static/testdata/aggregates/single-aggregate-app.AggregateHandler",
+										),
+										"MessageNamesValue": MatchAllFields(Fields{
+											"Produced": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
+											}),
+											"Consumed": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageF{}): Equal(message.EventRole),
+											}),
+										}),
+										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
+									}),
+								),
+							}),
+						}),
+					),
+				),
+			)
+		})
+	})
+
+	When("the application contains multiple aggregate handlers", func() {
+		It("returns all of the aggregate handler configurations", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/aggregates/multiple-aggregate-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+
+			Expect(apps).To(
+				ConsistOf(
+					PointTo(
+						MatchAllFields(Fields{
+							"IdentityValue": Equal(
+								configkit.Identity{
+									Name: "<multiple-aggregate-app>",
+									Key:  "66abab58-e0cd-4d50-90c2-b0bd093ea2ba",
+								},
+							),
+							"TypeNameValue": Equal(
+								"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.App",
+							),
+							"MessageNamesValue": Equal(configkit.EntityMessageNames{}),
+							"HandlersValue": MatchAllKeys(Keys{
+								configkit.Identity{
+									Name: "<first-aggregate>",
+									Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
+								}: PointTo(
+									MatchAllFields(Fields{
+										"IdentityValue": Equal(
+											configkit.Identity{
+												Name: "<first-aggregate>",
+												Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
+											},
+										),
+										"TypeNameValue": Equal(
+											"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.FirstAggregateHandler",
+										),
+										"MessageNamesValue": MatchAllFields(Fields{
+											"Produced": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageC{}): Equal(message.CommandRole),
+											}),
+											"Consumed": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageF{}): Equal(message.EventRole),
+											}),
+										}),
+										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
+									}),
+								),
+								configkit.Identity{
+									Name: "<second-aggregate>",
+									Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
+								}: PointTo(
+									MatchAllFields(Fields{
+										"IdentityValue": Equal(
+											configkit.Identity{
+												Name: "<second-aggregate>",
+												Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
+											},
+										),
+										"TypeNameValue": Equal(
+											"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.SecondAggregateHandler",
+										),
+										"MessageNamesValue": MatchAllFields(Fields{
+											"Produced": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageG{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageH{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageI{}): Equal(message.CommandRole),
+											}),
+											"Consumed": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageJ{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageK{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageL{}): Equal(message.EventRole),
+											}),
+										}),
+										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
+									}),
+								),
+							}),
+						}),
+					),
+				),
+			)
+		})
+	})
+})

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -2,6 +2,7 @@ package static_test
 
 import (
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/internal/entity"
 	"github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/configkit/static"
 	"github.com/dogmatiq/dogma/fixtures"
@@ -156,6 +157,96 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 												message.NameOf(fixtures.MessageJ{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageK{}): Equal(message.EventRole),
 												message.NameOf(fixtures.MessageL{}): Equal(message.EventRole),
+											}),
+										}),
+										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),
+									}),
+								),
+							}),
+						}),
+					),
+				),
+			)
+		})
+	})
+
+	When("a nil value passed as an aggregate handler", func() {
+		It("does not returns the aggregate handler configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/aggregates/nil-aggregate-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(ConsistOf(
+				&entity.Application{
+					IdentityValue: configkit.Identity{
+						Name: "<nil-aggregate-app>",
+						Key:  "250738eb-7728-4414-a850-1afefb04dbb4",
+					},
+					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/aggregates/nil-aggregate-app.App",
+					MessageNamesValue: configkit.EntityMessageNames{
+						Produced: nil,
+						Consumed: nil,
+					},
+					HandlersValue: configkit.HandlerSet{},
+				},
+			))
+		})
+	})
+
+	When("a nil value passed as a message while configuring an aggregate handler", func() {
+		It("skips the nil value message", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/aggregates/nil-message-aggregate-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+
+			Expect(apps).To(
+				ConsistOf(
+					PointTo(
+						MatchAllFields(Fields{
+							"IdentityValue": Equal(
+								configkit.Identity{
+									Name: "<nil-message-aggregate-app>",
+									Key:  "77199eb1-c893-4151-aab8-5088f6db4ea6",
+								},
+							),
+							"TypeNameValue": Equal(
+								"github.com/dogmatiq/configkit/static/testdata/aggregates/nil-message-aggregate-app.App",
+							),
+							"MessageNamesValue": Equal(configkit.EntityMessageNames{}),
+							"HandlersValue": MatchAllKeys(Keys{
+								configkit.Identity{
+									Name: "<nil-message-aggregate>",
+									Key:  "99271492-1ec3-475f-b154-3e69cda11155",
+								}: PointTo(
+									MatchAllFields(Fields{
+										"IdentityValue": Equal(
+											configkit.Identity{
+												Name: "<nil-message-aggregate>",
+												Key:  "99271492-1ec3-475f-b154-3e69cda11155",
+											},
+										),
+										"TypeNameValue": Equal(
+											"github.com/dogmatiq/configkit/static/testdata/aggregates/nil-message-aggregate-app.AggregateHandler",
+										),
+										"MessageNamesValue": MatchAllFields(Fields{
+											"Consumed": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageA{}): Equal(message.CommandRole),
+												message.NameOf(fixtures.MessageB{}): Equal(message.CommandRole),
+											}),
+											"Produced": MatchAllKeys(Keys{
+												message.NameOf(fixtures.MessageD{}): Equal(message.EventRole),
+												message.NameOf(fixtures.MessageE{}): Equal(message.EventRole),
 											}),
 										}),
 										"HandlerTypeValue": Equal(configkit.AggregateHandlerType),

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -70,53 +70,23 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 			Expect(apps).To(HaveLen(1))
 			Expect(apps[0].Handlers().Aggregates()).To(HaveLen(2))
 
-			a1, ok := apps[0].Handlers().ByIdentity(
-				configkit.Identity{
-					Name: "<first-aggregate>",
-					Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
-				},
-			)
-			Expect(ok).To(BeTrue())
-			Expect(a1.TypeName()).To(
-				Equal(
-					"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.FirstAggregateHandler",
-				),
-			)
-			Expect(a1.HandlerType()).To(Equal(configkit.AggregateHandlerType))
-			Expect(a1.MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Consumed: message.NameRoles{
-						cfixtures.MessageATypeName: message.CommandRole,
-					},
-					Produced: message.NameRoles{
-						cfixtures.MessageBTypeName: message.EventRole,
-					},
-				},
-			))
+			var identities []configkit.Identity
+			for _, a := range apps[0].Handlers().Aggregates() {
+				identities = append(identities, a.Identity())
+			}
 
-			a2, ok := apps[0].Handlers().ByIdentity(
-				configkit.Identity{
-					Name: "<second-aggregate>",
-					Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
-				},
-			)
-			Expect(ok).To(BeTrue())
-			Expect(a2.TypeName()).To(
-				Equal(
-					"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.SecondAggregateHandler",
+			Expect(identities).To(
+				ConsistOf(
+					configkit.Identity{
+						Name: "<first-aggregate>",
+						Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
+					},
+					configkit.Identity{
+						Name: "<second-aggregate>",
+						Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
+					},
 				),
 			)
-			Expect(a2.HandlerType()).To(Equal(configkit.AggregateHandlerType))
-			Expect(a2.MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Consumed: message.NameRoles{
-						cfixtures.MessageCTypeName: message.CommandRole,
-					},
-					Produced: message.NameRoles{
-						cfixtures.MessageDTypeName: message.EventRole,
-					},
-				},
-			))
 		})
 	})
 

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -68,7 +68,6 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 
 			apps := FromPackages(pkgs)
 			Expect(apps).To(HaveLen(1))
-			Expect(apps[0].Handlers().Aggregates()).To(HaveLen(2))
 
 			var identities []configkit.Identity
 			for _, a := range apps[0].Handlers().Aggregates() {
@@ -90,8 +89,8 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 		})
 	})
 
-	When("a nil value passed as an aggregate handler", func() {
-		It("does not returns the aggregate handler configuration", func() {
+	When("a nil value is passed as an aggregate handler", func() {
+		It("does not add an aggregate handler to the application configuration", func() {
 			cfg := packages.Config{
 				Mode: packages.LoadAllSyntax,
 				Dir:  "testdata/aggregates/nil-aggregate-app",
@@ -106,8 +105,8 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 		})
 	})
 
-	When("a nil value passed as a message while configuring an aggregate handler", func() {
-		It("skips the nil value message", func() {
+	When("a nil value is passed as a message", func() {
+		It("does not add the message to the aggregate configuration", func() {
 			cfg := packages.Config{
 				Mode: packages.LoadAllSyntax,
 				Dir:  "testdata/aggregates/nil-message-aggregate-app",

--- a/static/aggregate_test.go
+++ b/static/aggregate_test.go
@@ -70,15 +70,13 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 			Expect(apps).To(HaveLen(1))
 			Expect(apps[0].Handlers().Aggregates()).To(HaveLen(2))
 
-			a1 := apps[0].Handlers().Aggregates()[0]
-			Expect(a1.Identity()).To(
-				Equal(
-					configkit.Identity{
-						Name: "<first-aggregate>",
-						Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
-					},
-				),
+			a1, ok := apps[0].Handlers().ByIdentity(
+				configkit.Identity{
+					Name: "<first-aggregate>",
+					Key:  "e6300d8d-6530-405e-9729-e9ca21df23d3",
+				},
 			)
+			Expect(ok).To(BeTrue())
 			Expect(a1.TypeName()).To(
 				Equal(
 					"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.FirstAggregateHandler",
@@ -96,15 +94,13 @@ var _ = Describe("func FromPackages() (aggregate analysis)", func() {
 				},
 			))
 
-			a2 := apps[0].Handlers().Aggregates()[1]
-			Expect(a2.Identity()).To(
-				Equal(
-					configkit.Identity{
-						Name: "<second-aggregate>",
-						Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
-					},
-				),
+			a2, ok := apps[0].Handlers().ByIdentity(
+				configkit.Identity{
+					Name: "<second-aggregate>",
+					Key:  "feeb96d0-c56b-4e58-9cd0-d393683c2ec7",
+				},
 			)
+			Expect(ok).To(BeTrue())
 			Expect(a2.TypeName()).To(
 				Equal(
 					"github.com/dogmatiq/configkit/static/testdata/aggregates/multiple-aggregate-app.SecondAggregateHandler",

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -21,7 +21,7 @@ func analyzeApplication(prog *ssa.Program, typ types.Type) configkit.Application
 		MessageNamesValue: configkit.EntityMessageNames{},
 	}
 
-	pkg := getTypePkg(typ)
+	pkg := pkgOfNamedType(typ)
 	fn := prog.LookupMethod(typ, pkg, "Configure")
 
 	for _, c := range findConfigurerCalls(fn) {
@@ -97,7 +97,7 @@ func analyzeHandler(
 		},
 	}
 
-	pkg := getTypePkg(typ)
+	pkg := pkgOfNamedType(typ)
 	fn := prog.LookupMethod(typ, pkg, "Configure")
 
 	for _, c := range findConfigurerCalls(fn) {

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -81,11 +81,8 @@ func analyzeIdentityCall(c *ssa.Call) configkit.Identity {
 	return ident
 }
 
-// analyzeHandler analyzes the application's handler from the given type to
-// deduce its handler configuration.
-//
-// It is assumed that the caller knows what type this handler is and passes
-// handler's type through ht parameter.
+// analyzeHandler analyzes a type that implements one of the Dogma handler
+// interfaces to deduce its handler configuration.
 func analyzeHandler(
 	prog *ssa.Program,
 	typ types.Type,
@@ -129,14 +126,16 @@ func analyzeHandler(
 	return hdr
 }
 
-// getTypePkg returns a package from the given type.
-func getTypePkg(typ types.Type) *types.Package {
+// pkgOfNamedType returns the package in which typ is declared.
+//
+// It panics if typ is not a named type or a pointer to a named type.
+func pkgOfNamedType(typ types.Type) *types.Package {
 	switch t := typ.(type) {
 	case *types.Named:
 		return t.Obj().Pkg()
 	case *types.Pointer:
-		return t.Elem().(*types.Named).Obj().Pkg()
+		return pkgOfNamedType(t.Elem())
 	default:
-		panic(fmt.Sprintf("cannot analyze package for type %v", typ))
+		panic(fmt.Sprintf("cannot determine package for anonymous or built-in type %v", typ))
 	}
 }

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -31,13 +31,15 @@ func analyzeApplication(prog *ssa.Program, typ types.Type) configkit.Application
 		case "Identity":
 			app.IdentityValue = analyzeIdentityCall(c)
 		case "RegisterAggregate":
-			app.HandlersValue.Add(
-				analyzeHandler(
-					prog,
-					args[0].(*ssa.MakeInterface).X.Type(),
-					configkit.AggregateHandlerType,
-				),
-			)
+			if mi, ok := args[0].(*ssa.MakeInterface); ok {
+				app.HandlersValue.Add(
+					analyzeHandler(
+						prog,
+						mi.X.Type(),
+						configkit.AggregateHandlerType,
+					),
+				)
+			}
 		}
 	}
 
@@ -107,19 +109,23 @@ func analyzeHandler(
 		case "Identity":
 			hdr.IdentityValue = analyzeIdentityCall(c)
 		case "ConsumesCommandType":
-			hdr.MessageNamesValue.Consumed.Add(
-				message.NameFromType(
-					args[0].(*ssa.MakeInterface).X.Type(),
-				),
-				message.CommandRole,
-			)
+			if mi, ok := args[0].(*ssa.MakeInterface); ok {
+				hdr.MessageNamesValue.Consumed.Add(
+					message.NameFromType(
+						mi.X.Type(),
+					),
+					message.CommandRole,
+				)
+			}
 		case "ProducesEventType":
-			hdr.MessageNamesValue.Produced.Add(
-				message.NameFromType(
-					args[0].(*ssa.MakeInterface).X.Type(),
-				),
-				message.EventRole,
-			)
+			if mi, ok := args[0].(*ssa.MakeInterface); ok {
+				hdr.MessageNamesValue.Produced.Add(
+					message.NameFromType(
+						mi.X.Type(),
+					),
+					message.EventRole,
+				)
+			}
 		}
 	}
 

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -107,14 +107,14 @@ func analyzeHandler(
 		case "Identity":
 			hdr.IdentityValue = analyzeIdentityCall(c)
 		case "ConsumesCommandType":
-			hdr.MessageNamesValue.Produced.Add(
+			hdr.MessageNamesValue.Consumed.Add(
 				message.NameFromType(
 					args[0].(*ssa.MakeInterface).X.Type(),
 				),
 				message.CommandRole,
 			)
 		case "ProducesEventType":
-			hdr.MessageNamesValue.Consumed.Add(
+			hdr.MessageNamesValue.Produced.Add(
 				message.NameFromType(
 					args[0].(*ssa.MakeInterface).X.Type(),
 				),

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -33,7 +33,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})
@@ -62,7 +62,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 				&entity.Application{
 					IdentityValue: configkit.Identity{
@@ -74,7 +74,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})
@@ -103,7 +103,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 				&entity.Application{
 					IdentityValue: configkit.Identity{
@@ -115,7 +115,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})
@@ -144,7 +144,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})

--- a/static/ident_test.go
+++ b/static/ident_test.go
@@ -33,7 +33,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})
@@ -62,7 +62,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})
@@ -91,7 +91,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: nil,
+					HandlersValue: configkit.HandlerSet{},
 				},
 			))
 		})

--- a/static/static.go
+++ b/static/static.go
@@ -55,12 +55,12 @@ func FromPackages(pkgs []*packages.Package) []configkit.Application {
 			// interface regardless of whether pointer receivers are used or
 			// not.
 			if types.Implements(m.Type(), iface) {
-				apps = append(apps, analyzeApplication(m.Package(), m.Type()))
+				apps = append(apps, analyzeApplication(prog, m.Type()))
 				continue
 			}
 
 			if p := types.NewPointer(m.Type()); types.Implements(p, iface) {
-				apps = append(apps, analyzeApplication(m.Package(), p))
+				apps = append(apps, analyzeApplication(prog, p))
 			}
 		}
 	}

--- a/static/testdata/aggregates/multiple-aggregate-app/app.go
+++ b/static/testdata/aggregates/multiple-aggregate-app/app.go
@@ -1,0 +1,15 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<multiple-aggregate-app>", "66abab58-e0cd-4d50-90c2-b0bd093ea2ba")
+
+	c.RegisterAggregate(FirstAggregateHandler{})
+	c.RegisterAggregate(SecondAggregateHandler{})
+}

--- a/static/testdata/aggregates/multiple-aggregate-app/first.go
+++ b/static/testdata/aggregates/multiple-aggregate-app/first.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// FirstAggregate is an aggregate used for testing.
+type FirstAggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (FirstAggregate) ApplyEvent(m dogma.Message) {}
+
+// FirstAggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type FirstAggregateHandler struct{}
+
+// New returns a new account instance.
+func (FirstAggregateHandler) New() dogma.AggregateRoot {
+	return FirstAggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (FirstAggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<first-aggregate>", "e6300d8d-6530-405e-9729-e9ca21df23d3")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ConsumesCommandType(fixtures.MessageB{})
+	c.ConsumesCommandType(fixtures.MessageC{})
+
+	c.ProducesEventType(fixtures.MessageD{})
+	c.ProducesEventType(fixtures.MessageE{})
+	c.ProducesEventType(fixtures.MessageF{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (FirstAggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<first-aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (FirstAggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/aggregates/multiple-aggregate-app/first.go
+++ b/static/testdata/aggregates/multiple-aggregate-app/first.go
@@ -26,12 +26,8 @@ func (FirstAggregateHandler) Configure(c dogma.AggregateConfigurer) {
 	c.Identity("<first-aggregate>", "e6300d8d-6530-405e-9729-e9ca21df23d3")
 
 	c.ConsumesCommandType(fixtures.MessageA{})
-	c.ConsumesCommandType(fixtures.MessageB{})
-	c.ConsumesCommandType(fixtures.MessageC{})
 
-	c.ProducesEventType(fixtures.MessageD{})
-	c.ProducesEventType(fixtures.MessageE{})
-	c.ProducesEventType(fixtures.MessageF{})
+	c.ProducesEventType(fixtures.MessageB{})
 }
 
 // RouteCommandToInstance returns the ID of the aggregate instance that is

--- a/static/testdata/aggregates/multiple-aggregate-app/second.go
+++ b/static/testdata/aggregates/multiple-aggregate-app/second.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// SecondAggregate is an aggregate used for testing.
+type SecondAggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (SecondAggregate) ApplyEvent(m dogma.Message) {}
+
+// SecondAggregateHandler is a test implementation of
+// dogma.AggregateMessageHandler.
+type SecondAggregateHandler struct{}
+
+// New returns a new account instance.
+func (SecondAggregateHandler) New() dogma.AggregateRoot {
+	return SecondAggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (SecondAggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<second-aggregate>", "feeb96d0-c56b-4e58-9cd0-d393683c2ec7")
+
+	c.ConsumesCommandType(fixtures.MessageG{})
+	c.ConsumesCommandType(fixtures.MessageH{})
+	c.ConsumesCommandType(fixtures.MessageI{})
+
+	c.ProducesEventType(fixtures.MessageJ{})
+	c.ProducesEventType(fixtures.MessageK{})
+	c.ProducesEventType(fixtures.MessageL{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (SecondAggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<second-aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (SecondAggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/aggregates/multiple-aggregate-app/second.go
+++ b/static/testdata/aggregates/multiple-aggregate-app/second.go
@@ -26,13 +26,9 @@ func (SecondAggregateHandler) New() dogma.AggregateRoot {
 func (SecondAggregateHandler) Configure(c dogma.AggregateConfigurer) {
 	c.Identity("<second-aggregate>", "feeb96d0-c56b-4e58-9cd0-d393683c2ec7")
 
-	c.ConsumesCommandType(fixtures.MessageG{})
-	c.ConsumesCommandType(fixtures.MessageH{})
-	c.ConsumesCommandType(fixtures.MessageI{})
+	c.ConsumesCommandType(fixtures.MessageC{})
 
-	c.ProducesEventType(fixtures.MessageJ{})
-	c.ProducesEventType(fixtures.MessageK{})
-	c.ProducesEventType(fixtures.MessageL{})
+	c.ProducesEventType(fixtures.MessageD{})
 }
 
 // RouteCommandToInstance returns the ID of the aggregate instance that is

--- a/static/testdata/aggregates/nil-aggregate-app/app.go
+++ b/static/testdata/aggregates/nil-aggregate-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<nil-aggregate-app>", "250738eb-7728-4414-a850-1afefb04dbb4")
+
+	c.RegisterAggregate(nil)
+}

--- a/static/testdata/aggregates/nil-message-aggregate-app/aggregate.go
+++ b/static/testdata/aggregates/nil-message-aggregate-app/aggregate.go
@@ -26,11 +26,9 @@ func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
 	c.Identity("<nil-message-aggregate>", "99271492-1ec3-475f-b154-3e69cda11155")
 
 	c.ConsumesCommandType(fixtures.MessageA{})
-	c.ConsumesCommandType(fixtures.MessageB{})
 	c.ConsumesCommandType(nil)
 
-	c.ProducesEventType(fixtures.MessageD{})
-	c.ProducesEventType(fixtures.MessageE{})
+	c.ProducesEventType(fixtures.MessageB{})
 	c.ProducesEventType(nil)
 }
 

--- a/static/testdata/aggregates/nil-message-aggregate-app/aggregate.go
+++ b/static/testdata/aggregates/nil-message-aggregate-app/aggregate.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Aggregate is an aggregate used for testing.
+type Aggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Aggregate) ApplyEvent(m dogma.Message) {}
+
+// AggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateHandler struct{}
+
+// New returns a new account instance.
+func (AggregateHandler) New() dogma.AggregateRoot {
+	return Aggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<nil-message-aggregate>", "99271492-1ec3-475f-b154-3e69cda11155")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ConsumesCommandType(fixtures.MessageB{})
+	c.ConsumesCommandType(nil)
+
+	c.ProducesEventType(fixtures.MessageD{})
+	c.ProducesEventType(fixtures.MessageE{})
+	c.ProducesEventType(nil)
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (AggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<nil-message-aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (AggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/aggregates/nil-message-aggregate-app/app.go
+++ b/static/testdata/aggregates/nil-message-aggregate-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<nil-message-aggregate-app>", "77199eb1-c893-4151-aab8-5088f6db4ea6")
+
+	c.RegisterAggregate(AggregateHandler{})
+}

--- a/static/testdata/aggregates/single-aggregate-app/aggregate.go
+++ b/static/testdata/aggregates/single-aggregate-app/aggregate.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Aggregate is an aggregate used for testing.
+type Aggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Aggregate) ApplyEvent(m dogma.Message) {}
+
+// AggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateHandler struct{}
+
+// New returns a new account instance.
+func (AggregateHandler) New() dogma.AggregateRoot {
+	return Aggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<aggregate>", "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ConsumesCommandType(fixtures.MessageB{})
+	c.ConsumesCommandType(fixtures.MessageC{})
+
+	c.ProducesEventType(fixtures.MessageD{})
+	c.ProducesEventType(fixtures.MessageE{})
+	c.ProducesEventType(fixtures.MessageF{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (AggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (AggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/aggregates/single-aggregate-app/aggregate.go
+++ b/static/testdata/aggregates/single-aggregate-app/aggregate.go
@@ -27,11 +27,9 @@ func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
 
 	c.ConsumesCommandType(fixtures.MessageA{})
 	c.ConsumesCommandType(fixtures.MessageB{})
-	c.ConsumesCommandType(fixtures.MessageC{})
 
+	c.ProducesEventType(fixtures.MessageC{})
 	c.ProducesEventType(fixtures.MessageD{})
-	c.ProducesEventType(fixtures.MessageE{})
-	c.ProducesEventType(fixtures.MessageF{})
 }
 
 // RouteCommandToInstance returns the ID of the aggregate instance that is

--- a/static/testdata/aggregates/single-aggregate-app/app.go
+++ b/static/testdata/aggregates/single-aggregate-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<single-aggregate-app>", "3bc3849b-abe0-4c4e-9db4-e48dc28c9a26")
+
+	c.RegisterAggregate(AggregateHandler{})
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->


#### What change does this introduce?

This change is the next step to introduce the static analysis of the configuration data of Dogma applications. This particular change concentrates on analysing Dogma application aggregate handlers.

#### Why make this change?

This change is required as the next step to implement the feature of loading Dogma application configurations using static analysis.

#### Is there anything you are unsure about?

The aggregate handler tests are using gomega's `gstruct` package. They do make the test look bulkier and I am not sure if it's a right fit.

#### What issues does this relate to?

Partially addresses #104.
