### PR TITLE
Ensure handlers are found inside fields of the application type.

### DIFF
--- a/static/app_test.go
+++ b/static/app_test.go
@@ -165,4 +165,35 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			Expect(apps).To(BeEmpty())
 		})
 	})
+
+	When("a field within the application type is registered as a handler", func() {
+		It("includes the handler in the application configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/apps/handler-from-field",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers().Aggregates()).To(HaveLen(1))
+
+			a := apps[0].Handlers().Aggregates()[0]
+			Expect(a.Identity()).To(
+				Equal(
+					configkit.Identity{
+						Name: "<aggregate>",
+						Key:  "195ede4a-3f26-4d19-a8fe-41b2a5f92d06",
+					},
+				),
+			)
+			Expect(a.TypeName()).To(
+				Equal(
+					"*github.com/dogmatiq/configkit/static/testdata/apps/handler-from-field.AggregateHandler",
+				),
+			)
+		})
+	})
 })

--- a/static/testdata/apps/handler-from-field/aggregate.go
+++ b/static/testdata/apps/handler-from-field/aggregate.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Aggregate is an aggregate used for testing.
+type Aggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Aggregate) ApplyEvent(m dogma.Message) {}
+
+// AggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateHandler struct{}
+
+// New returns a new account instance.
+func (*AggregateHandler) New() dogma.AggregateRoot {
+	return Aggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (*AggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<aggregate>", "195ede4a-3f26-4d19-a8fe-41b2a5f92d06")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+
+	c.ProducesEventType(fixtures.MessageB{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (*AggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (*AggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/apps/handler-from-field/app.go
+++ b/static/testdata/apps/handler-from-field/app.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+)
+
+// App implements dogma.Application interface.
+type App struct {
+	Aggregate AggregateHandler
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (a App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<app>", "7468a57f-20f0-4d11-9aad-48fcd553a908")
+
+	c.RegisterAggregate(&a.Aggregate)
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds a new test that ensures the static analyzer can find handlers that are stored in fields of the application type.

#### Why make this change?

This is a common pattern we have started using when developing real applications, so it seems important to test for this.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Partially addresses #104 
