### PR TITLE
Add support for analysing projection handlers.

### DIFF
--- a/static/analysis.go
+++ b/static/analysis.go
@@ -44,6 +44,13 @@ func analyzeApplication(prog *ssa.Program, typ types.Type) configkit.Application
 				app.HandlersValue,
 				configkit.ProcessHandlerType,
 			)
+		case "RegisterProjection":
+			addHandlerFromArguments(
+				prog,
+				args,
+				app.HandlersValue,
+				configkit.ProjectionHandlerType,
+			)
 		}
 	}
 

--- a/static/projection_test.go
+++ b/static/projection_test.go
@@ -1,0 +1,144 @@
+package static_test
+
+import (
+	"github.com/dogmatiq/configkit"
+	cfixtures "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
+	. "github.com/dogmatiq/configkit/static"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/tools/go/packages"
+)
+
+var _ = Describe("func FromPackages() (projection analysis)", func() {
+	When("the application contains a single projection handler", func() {
+		It("returns the projection handler configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/projections/single-projection-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers().Projections()).To(HaveLen(1))
+
+			a := apps[0].Handlers().Projections()[0]
+			Expect(a.Identity()).To(
+				Equal(
+					configkit.Identity{
+						Name: "<projection>",
+						Key:  "1c964b02-623e-4ae1-82e7-1f678ef875c8",
+					},
+				),
+			)
+			Expect(a.TypeName()).To(
+				Equal(
+					"github.com/dogmatiq/configkit/static/testdata/projections/single-projection-app.ProjectionHandler",
+				),
+			)
+			Expect(a.HandlerType()).To(Equal(configkit.ProjectionHandlerType))
+
+			Expect(a.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.EventRole,
+						cfixtures.MessageBTypeName: message.EventRole,
+					},
+					Produced: message.NameRoles{},
+				},
+			))
+		})
+	})
+
+	When("the application contains multiple projection handlers", func() {
+		It("returns all of the projection handler configurations", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/projections/multiple-projection-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+
+			var identities []configkit.Identity
+			for _, a := range apps[0].Handlers().Projections() {
+				identities = append(identities, a.Identity())
+			}
+
+			Expect(identities).To(
+				ConsistOf(
+					configkit.Identity{
+						Name: "<first-projection>",
+						Key:  "9174783f-4f12-4619-b5c6-c4ab70bd0937",
+					},
+					configkit.Identity{
+						Name: "<second-projection>",
+						Key:  "2e22850e-7c84-4b3f-b8b3-25ac743d90f2",
+					},
+				),
+			)
+		})
+	})
+
+	When("a nil value is passed as a projection handler", func() {
+		It("does not add an process handler to the application configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/projections/nil-projection-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
+		})
+	})
+
+	When("a nil value is passed as a message", func() {
+		It("does not add the message to the projection configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/projections/nil-message-projection-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers().Projections()).To(HaveLen(1))
+
+			a := apps[0].Handlers().Projections()[0]
+			Expect(a.Identity()).To(
+				Equal(
+					configkit.Identity{
+						Name: "<nil-message-projection>",
+						Key:  "d594ac29-eea2-4651-acd4-88c7c34eaab1",
+					},
+				),
+			)
+			Expect(a.TypeName()).To(
+				Equal(
+					"github.com/dogmatiq/configkit/static/testdata/projections/nil-message-projection-app.ProjectionHandler",
+				),
+			)
+			Expect(a.HandlerType()).To(Equal(configkit.ProjectionHandlerType))
+			Expect(a.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.EventRole,
+					},
+					Produced: message.NameRoles{},
+				},
+			))
+		})
+	})
+})

--- a/static/testdata/projections/multiple-projection-app/app.go
+++ b/static/testdata/projections/multiple-projection-app/app.go
@@ -1,0 +1,15 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<multiple-projection-app>", "e9d3c0df-f527-4604-a6c6-c8bc96a56869")
+
+	c.RegisterProjection(FirstProjectionHandler{})
+	c.RegisterProjection(SecondProjectionHandler{})
+}

--- a/static/testdata/projections/multiple-projection-app/first.go
+++ b/static/testdata/projections/multiple-projection-app/first.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// FirstProjection is a projection used for testing.
+type FirstProjection struct{}
+
+// FirstProjectionHandler is a test implementation of
+// dogma.ProjectionMessageHandler.
+type FirstProjectionHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (FirstProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
+	c.Identity("<first-projection>", "9174783f-4f12-4619-b5c6-c4ab70bd0937")
+
+	c.ConsumesEventType(fixtures.MessageA{})
+}
+
+// HandleEvent updates the projection to reflect the occurrence of an event.
+func (FirstProjectionHandler) HandleEvent(
+	ctx context.Context,
+	r, c, n []byte,
+	s dogma.ProjectionEventScope,
+	m dogma.Message,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+func (FirstProjectionHandler) ResourceVersion(
+	ctx context.Context,
+	r []byte,
+) ([]byte, error) {
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be
+// used in any future calls to HandleEvent().
+func (FirstProjectionHandler) CloseResource(ctx context.Context, r []byte) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (FirstProjectionHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}
+
+// Compact reduces the size of the projection's data.
+func (FirstProjectionHandler) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return nil
+}

--- a/static/testdata/projections/multiple-projection-app/second.go
+++ b/static/testdata/projections/multiple-projection-app/second.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// SecondProjection is a projection used for testing.
+type SecondProjection struct{}
+
+// SecondProjectionHandler is a test implementation of
+// dogma.ProjectionMessageHandler.
+type SecondProjectionHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (SecondProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
+	c.Identity("<second-projection>", "2e22850e-7c84-4b3f-b8b3-25ac743d90f2")
+
+	c.ConsumesEventType(fixtures.MessageB{})
+}
+
+// HandleEvent updates the projection to reflect the occurrence of an event.
+func (SecondProjectionHandler) HandleEvent(
+	ctx context.Context,
+	r, c, n []byte,
+	s dogma.ProjectionEventScope,
+	m dogma.Message,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+func (SecondProjectionHandler) ResourceVersion(
+	ctx context.Context,
+	r []byte,
+) ([]byte, error) {
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be
+// used in any future calls to HandleEvent().
+func (SecondProjectionHandler) CloseResource(ctx context.Context, r []byte) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (SecondProjectionHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}
+
+// Compact reduces the size of the projection's data.
+func (SecondProjectionHandler) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return nil
+}

--- a/static/testdata/projections/nil-message-projection-app/app.go
+++ b/static/testdata/projections/nil-message-projection-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<nil-message-projection-app>", "d6ff7e9a-f070-4447-8177-fa29fa637de7")
+
+	c.RegisterProjection(ProjectionHandler{})
+}

--- a/static/testdata/projections/nil-message-projection-app/projection.go
+++ b/static/testdata/projections/nil-message-projection-app/projection.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Projection is a projection used for testing.
+type Projection struct{}
+
+// ProjectionHandler is a test implementation of dogma.ProjectionMessageHandler.
+type ProjectionHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (ProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
+	c.Identity("<nil-message-projection>", "d594ac29-eea2-4651-acd4-88c7c34eaab1")
+
+	c.ConsumesEventType(fixtures.MessageA{})
+	c.ConsumesEventType(nil)
+}
+
+// HandleEvent updates the projection to reflect the occurrence of an event.
+func (ProjectionHandler) HandleEvent(
+	ctx context.Context,
+	r, c, n []byte,
+	s dogma.ProjectionEventScope,
+	m dogma.Message,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+func (ProjectionHandler) ResourceVersion(
+	ctx context.Context,
+	r []byte,
+) ([]byte, error) {
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be
+// used in any future calls to HandleEvent().
+func (ProjectionHandler) CloseResource(ctx context.Context, r []byte) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (ProjectionHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}
+
+// Compact reduces the size of the projection's data.
+func (ProjectionHandler) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return nil
+}

--- a/static/testdata/projections/nil-projection-app/app.go
+++ b/static/testdata/projections/nil-projection-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<nil-projection-app>", "aa8263fd-6333-41f0-8cd4-6a72d467cedf")
+
+	c.RegisterProjection(nil)
+}

--- a/static/testdata/projections/single-projection-app/app.go
+++ b/static/testdata/projections/single-projection-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<single-projection-app>", "009eed19-bc2b-4a8c-8aa1-64b57da01e6e")
+
+	c.RegisterProjection(ProjectionHandler{})
+}

--- a/static/testdata/projections/single-projection-app/projection.go
+++ b/static/testdata/projections/single-projection-app/projection.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Projection is a projection used for testing.
+type Projection struct{}
+
+// ProjectionHandler is a test implementation of dogma.ProjectionMessageHandler.
+type ProjectionHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (ProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
+	c.Identity("<projection>", "1c964b02-623e-4ae1-82e7-1f678ef875c8")
+
+	c.ConsumesEventType(fixtures.MessageA{})
+	c.ConsumesEventType(fixtures.MessageB{})
+}
+
+// HandleEvent updates the projection to reflect the occurrence of an event.
+func (ProjectionHandler) HandleEvent(
+	ctx context.Context,
+	r, c, n []byte,
+	s dogma.ProjectionEventScope,
+	m dogma.Message,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+func (ProjectionHandler) ResourceVersion(
+	ctx context.Context,
+	r []byte,
+) ([]byte, error) {
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be
+// used in any future calls to HandleEvent().
+func (ProjectionHandler) CloseResource(ctx context.Context, r []byte) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (ProjectionHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}
+
+// Compact reduces the size of the projection's data.
+func (ProjectionHandler) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return nil
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->


#### What change does this introduce?

This change is the next step to introduce the static analysis of the configuration data of Dogma applications. This particular change concentrates on analysing Dogma application projection handlers.

#### Why make this change?

This change is required as the next step to implement the feature of loading Dogma application configurations using static analysis.

#### Is there anything you are unsure about?

No.

#### What issues does this relate to?

Partially addresses #104.
