### PR TITLE
Pointer handler with non pointer methodset

### DIFF
--- a/static/app_test.go
+++ b/static/app_test.go
@@ -196,4 +196,35 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			)
 		})
 	})
+
+	When("a handler with a non-pointer methodset is registered as a pointer", func() {
+		It("includes the handler in the application configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/apps/pointer-handler-with-non-pointer-methodset",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers().Aggregates()).To(HaveLen(1))
+
+			a := apps[0].Handlers().Aggregates()[0]
+			Expect(a.Identity()).To(
+				Equal(
+					configkit.Identity{
+						Name: "<aggregate>",
+						Key:  "dad3b670-0852-4711-9efb-af25679734ee",
+					},
+				),
+			)
+			Expect(a.TypeName()).To(
+				Equal(
+					"*github.com/dogmatiq/configkit/static/testdata/apps/pointer-handler-with-non-pointer-methodset.AggregateHandler",
+				),
+			)
+		})
+	})
 })

--- a/static/testdata/apps/pointer-handler-with-non-pointer-methodset/aggregate.go
+++ b/static/testdata/apps/pointer-handler-with-non-pointer-methodset/aggregate.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Aggregate is an aggregate used for testing.
+type Aggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Aggregate) ApplyEvent(m dogma.Message) {}
+
+// AggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateHandler struct{}
+
+// New returns a new account instance.
+func (AggregateHandler) New() dogma.AggregateRoot {
+	return Aggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<aggregate>", "dad3b670-0852-4711-9efb-af25679734ee")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+
+	c.ProducesEventType(fixtures.MessageB{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (AggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (AggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/apps/pointer-handler-with-non-pointer-methodset/app.go
+++ b/static/testdata/apps/pointer-handler-with-non-pointer-methodset/app.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+)
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (a App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<app>", "dc3ef830-ee59-472a-a8d7-523f0570a918")
+
+	c.RegisterAggregate(&AggregateHandler{})
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This commit changes the static analysis of handlers and applications such that calls made to methods of the various "configurer" types are still detected even if they are made indirectly, that is, by a function called within `Configure()` rather than directly within `Configure()` itself.

#### Why make this change?

This was initially found to be required to handle the indirection that occurs when you register a handler as a pointer but the methodset that implements the handler interface is actually defined with a non-pointer receiver, but it has been written in such a way that it will follow any arbitrary function call within `Configure()` that is passed the `c` as an argument.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Partially addresses #104 
