### PR TITLE
Add integration static analysis.

### DIFF
--- a/static/analysis.go
+++ b/static/analysis.go
@@ -51,6 +51,13 @@ func analyzeApplication(prog *ssa.Program, typ types.Type) configkit.Application
 				app.HandlersValue,
 				configkit.ProjectionHandlerType,
 			)
+		case "RegisterIntegration":
+			addHandlerFromArguments(
+				prog,
+				args,
+				app.HandlersValue,
+				configkit.IntegrationHandlerType,
+			)
 		}
 	}
 

--- a/static/integration_test.go
+++ b/static/integration_test.go
@@ -1,0 +1,149 @@
+package static_test
+
+import (
+	"github.com/dogmatiq/configkit"
+	cfixtures "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
+	. "github.com/dogmatiq/configkit/static"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/tools/go/packages"
+)
+
+var _ = Describe("func FromPackages() (integration analysis)", func() {
+	When("the application contains a single integration handler", func() {
+		It("returns the integration handler configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/integrations/single-integration-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers().Integrations()).To(HaveLen(1))
+
+			a := apps[0].Handlers().Integrations()[0]
+			Expect(a.Identity()).To(
+				Equal(
+					configkit.Identity{
+						Name: "<integration>",
+						Key:  "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc",
+					},
+				),
+			)
+			Expect(a.TypeName()).To(
+				Equal(
+					"github.com/dogmatiq/configkit/static/testdata/integrations/single-integration-app.IntegrationHandler",
+				),
+			)
+			Expect(a.HandlerType()).To(Equal(configkit.IntegrationHandlerType))
+
+			Expect(a.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
+						cfixtures.MessageBTypeName: message.CommandRole,
+					},
+					Produced: message.NameRoles{
+						cfixtures.MessageCTypeName: message.EventRole,
+						cfixtures.MessageDTypeName: message.EventRole,
+					},
+				},
+			))
+		})
+	})
+
+	When("the application contains multiple integrations handlers", func() {
+		It("returns all of the integration handler configurations", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/integrations/multiple-integration-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+
+			var identities []configkit.Identity
+			for _, a := range apps[0].Handlers().Integrations() {
+				identities = append(identities, a.Identity())
+			}
+
+			Expect(identities).To(
+				ConsistOf(
+					configkit.Identity{
+						Name: "<first-integration>",
+						Key:  "14cf2812-eead-43b3-9c9c-10db5b469e94",
+					},
+					configkit.Identity{
+						Name: "<second-integration>",
+						Key:  "6bed3fbc-30e2-44c7-9a5b-e440ffe370d9",
+					},
+				),
+			)
+		})
+	})
+
+	When("a nil value is passed as an integration handler", func() {
+		It("does not add an integration handler to the application configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/integrations/nil-integration-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
+		})
+	})
+
+	When("a nil value is passed as a message", func() {
+		It("does not add the message to the integration configuration", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/integrations/nil-message-integration-app",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Handlers().Integrations()).To(HaveLen(1))
+
+			a := apps[0].Handlers().Integrations()[0]
+			Expect(a.Identity()).To(
+				Equal(
+					configkit.Identity{
+						Name: "<nil-message-integration>",
+						Key:  "e389bf6d-66fc-4355-b6f4-1e00fca724c5",
+					},
+				),
+			)
+			Expect(a.TypeName()).To(
+				Equal(
+					"github.com/dogmatiq/configkit/static/testdata/integrations/nil-message-integration-app.IntegrationHandler",
+				),
+			)
+			Expect(a.HandlerType()).To(Equal(configkit.IntegrationHandlerType))
+			Expect(a.MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
+					},
+					Produced: message.NameRoles{
+						cfixtures.MessageBTypeName: message.EventRole,
+					},
+				},
+			))
+		})
+	})
+})

--- a/static/testdata/integrations/multiple-integration-app/app.go
+++ b/static/testdata/integrations/multiple-integration-app/app.go
@@ -1,0 +1,15 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<multiple-integration-app>", "c01a4fef-0979-4468-bd7e-c9d371f82cd2")
+
+	c.RegisterIntegration(FirstIntegrationHandler{})
+	c.RegisterIntegration(SecondIntegrationHandler{})
+}

--- a/static/testdata/integrations/multiple-integration-app/first.go
+++ b/static/testdata/integrations/multiple-integration-app/first.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// FirstIntegration is an integration used for testing.
+type FirstIntegration struct{}
+
+// ApplyEvent updates the integration instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (FirstIntegration) ApplyEvent(m dogma.Message) {}
+
+// FirstIntegrationHandler is a test implementation of
+// dogma.IntegrationMessageHandler.
+type FirstIntegrationHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (FirstIntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
+	c.Identity("<first-integration>", "14cf2812-eead-43b3-9c9c-10db5b469e94")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+
+	c.ProducesEventType(fixtures.MessageB{})
+}
+
+// RouteCommandToInstance returns the ID of the integration instance that is
+// targetted by m.
+func (FirstIntegrationHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<first-integration>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (FirstIntegrationHandler) HandleCommand(
+	ctx context.Context,
+	s dogma.IntegrationCommandScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (FirstIntegrationHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/integrations/multiple-integration-app/second.go
+++ b/static/testdata/integrations/multiple-integration-app/second.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// SecondIntegration is an integration used for testing.
+type SecondIntegration struct{}
+
+// ApplyEvent updates the integration instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (SecondIntegration) ApplyEvent(m dogma.Message) {}
+
+// SecondIntegrationHandler is a test implementation of
+// dogma.IntegrationMessageHandler.
+type SecondIntegrationHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (SecondIntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
+	c.Identity("<second-integration>", "6bed3fbc-30e2-44c7-9a5b-e440ffe370d9")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+
+	c.ProducesEventType(fixtures.MessageB{})
+}
+
+// RouteCommandToInstance returns the ID of the integration instance that is
+// targetted by m.
+func (SecondIntegrationHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<second-integration>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (SecondIntegrationHandler) HandleCommand(
+	ctx context.Context,
+	s dogma.IntegrationCommandScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (SecondIntegrationHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/integrations/nil-integration-app/app.go
+++ b/static/testdata/integrations/nil-integration-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<nil-integration-app>", "e0075708-ca66-40e1-baf8-f5787e8d0a38")
+
+	c.RegisterIntegration(nil)
+}

--- a/static/testdata/integrations/nil-message-integration-app/app.go
+++ b/static/testdata/integrations/nil-message-integration-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<nil-message-integraion-app>", "dc0c1986-953b-445e-a5d0-3240c22c1abf")
+
+	c.RegisterIntegration(IntegrationHandler{})
+}

--- a/static/testdata/integrations/nil-message-integration-app/integration.go
+++ b/static/testdata/integrations/nil-message-integration-app/integration.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Integration is an integration used for testing.
+type Integration struct{}
+
+// ApplyEvent updates the integration instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Integration) ApplyEvent(m dogma.Message) {}
+
+// IntegrationHandler is a test implementation of
+// dogma.IntegrationMessageHandler.
+type IntegrationHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (IntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
+	c.Identity("<nil-message-integration>", "e389bf6d-66fc-4355-b6f4-1e00fca724c5")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ConsumesCommandType(nil)
+
+	c.ProducesEventType(fixtures.MessageB{})
+	c.ProducesEventType(nil)
+}
+
+// RouteCommandToInstance returns the ID of the integration instance that is
+// targetted by m.
+func (IntegrationHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<nil-message-integration>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (IntegrationHandler) HandleCommand(
+	ctx context.Context,
+	s dogma.IntegrationCommandScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (IntegrationHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/integrations/single-integration-app/app.go
+++ b/static/testdata/integrations/single-integration-app/app.go
@@ -1,0 +1,14 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<single-integration-app>", "cb5558eb-451a-4df3-8290-96e29ed793e7")
+
+	c.RegisterIntegration(IntegrationHandler{})
+}

--- a/static/testdata/integrations/single-integration-app/integration.go
+++ b/static/testdata/integrations/single-integration-app/integration.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Integration is an integration used for testing.
+type Integration struct{}
+
+// ApplyEvent updates the integration instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Integration) ApplyEvent(m dogma.Message) {}
+
+// IntegrationHandler is a test implementation of
+// dogma.IntegrationMessageHandler.
+type IntegrationHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (IntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
+	c.Identity("<integration>", "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ConsumesCommandType(fixtures.MessageB{})
+
+	c.ProducesEventType(fixtures.MessageC{})
+	c.ProducesEventType(fixtures.MessageD{})
+}
+
+// RouteCommandToInstance returns the ID of the integration instance that is
+// targetted by m.
+func (IntegrationHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<integration>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (IntegrationHandler) HandleCommand(
+	ctx context.Context,
+	s dogma.IntegrationCommandScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (IntegrationHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->


#### What change does this introduce?

This change is the next step to introduce the static analysis of the configuration data of Dogma applications. This particular change concentrates on analysing Dogma application integration handlers.

#### Why make this change?

This change is required as the next step to implement the feature of loading Dogma application configurations using static analysis.

#### Is there anything you are unsure about?

No.

#### What issues does this relate to?

Partially addresses #104.
