### PR TITLE
Remove internal types from static tests.

### DIFF
--- a/static/analysis.go
+++ b/static/analysis.go
@@ -61,6 +61,7 @@ func analyzeApplication(prog *ssa.Program, typ types.Type) configkit.Application
 		}
 	}
 
+	app.MessageNamesValue = app.HandlersValue.MessageNames()
 	return app
 }
 

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -68,48 +68,6 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 					},
 				),
 			)
-
-			Expect(
-				[]string{
-					apps[0].TypeName(),
-					apps[1].TypeName(),
-				},
-			).To(
-				ConsistOf(
-					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-pkgs/first.App",
-					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-pkgs/second.App",
-				),
-			)
-
-			Expect(
-				[]configkit.EntityMessageNames{
-					apps[0].MessageNames(),
-					apps[1].MessageNames(),
-				},
-			).To(
-				ConsistOf(
-					configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-				),
-			)
-
-			Expect(
-				[]configkit.HandlerSet{
-					apps[0].Handlers(),
-					apps[1].Handlers(),
-				},
-			).To(
-				ConsistOf(
-					configkit.HandlerSet{},
-					configkit.HandlerSet{},
-				),
-			)
 		})
 	})
 
@@ -143,48 +101,6 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 					},
 				),
 			)
-
-			Expect(
-				[]string{
-					apps[0].TypeName(),
-					apps[1].TypeName(),
-				},
-			).To(
-				ConsistOf(
-					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-single-pkg/apps.AppFirst",
-					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-single-pkg/apps.AppSecond",
-				),
-			)
-
-			Expect(
-				[]configkit.EntityMessageNames{
-					apps[0].MessageNames(),
-					apps[1].MessageNames(),
-				},
-			).To(
-				ConsistOf(
-					configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-				),
-			)
-
-			Expect(
-				[]configkit.HandlerSet{
-					apps[0].Handlers(),
-					apps[1].Handlers(),
-				},
-			).To(
-				ConsistOf(
-					configkit.HandlerSet{},
-					configkit.HandlerSet{},
-				),
-			)
 		})
 	})
 
@@ -209,11 +125,6 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 					},
 				),
 			)
-			Expect(apps[0].TypeName()).To(Equal("*github.com/dogmatiq/configkit/static/testdata/apps/pointer-receiver-app.App"))
-			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{},
-			))
-			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 
@@ -256,11 +167,6 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 					},
 				),
 			)
-			Expect(a.TypeName()).To(
-				Equal(
-					"*github.com/dogmatiq/configkit/static/testdata/apps/handler-from-field.AggregateHandler",
-				),
-			)
 		})
 	})
 
@@ -285,11 +191,6 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						Name: "<aggregate>",
 						Key:  "dad3b670-0852-4711-9efb-af25679734ee",
 					},
-				),
-			)
-			Expect(a.TypeName()).To(
-				Equal(
-					"*github.com/dogmatiq/configkit/static/testdata/apps/pointer-handler-with-non-pointer-methodset.AggregateHandler",
 				),
 			)
 		})

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -32,10 +32,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/apps/single-app.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Produced: nil,
-					Consumed: nil,
-				},
+				configkit.EntityMessageNames{},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
@@ -214,10 +211,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("*github.com/dogmatiq/configkit/static/testdata/apps/pointer-receiver-app.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Produced: nil,
-					Consumed: nil,
-				},
+				configkit.EntityMessageNames{},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -34,7 +34,10 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/apps/single-app.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{},
+				configkit.EntityMessageNames{
+					Produced: message.NameRoles{},
+					Consumed: message.NameRoles{},
+				},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
@@ -217,6 +220,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 						cfixtures.MessageATypeName: message.CommandRole,
 						cfixtures.MessageBTypeName: message.EventRole,
 						cfixtures.MessageCTypeName: message.EventRole,
+						cfixtures.MessageETypeName: message.TimeoutRole,
 					},
 					Produced: message.NameRoles{
 						cfixtures.MessageBTypeName: message.EventRole,

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -2,7 +2,6 @@ package static_test
 
 import (
 	"github.com/dogmatiq/configkit"
-	"github.com/dogmatiq/configkit/internal/entity"
 	. "github.com/dogmatiq/configkit/static"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,21 +20,24 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(apps[0].Identity()).To(
+				Equal(
+					configkit.Identity{
 						Name: "<app>",
 						Key:  "8a6baab1-ee64-402e-a081-e43f4bebc243",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/apps/single-app.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
+				),
+			)
+			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/apps/single-app.App"))
+			Expect(apps[0].MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Produced: nil,
+					Consumed: nil,
 				},
 			))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 
@@ -50,33 +52,67 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(2))
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(
+				[]configkit.Identity{
+					apps[0].Identity(),
+					apps[1].Identity(),
+				},
+			).To(
+				ConsistOf(
+					configkit.Identity{
 						Name: "<app-first>",
 						Key:  "b754902b-47c8-48fc-84d2-d920c9cbdaec",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-pkgs/first.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
-				},
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+					configkit.Identity{
 						Name: "<app-second>",
 						Key:  "bfaf2a16-23a0-495d-8098-051d77635822",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-pkgs/second.App",
-					MessageNamesValue: configkit.EntityMessageNames{
+				),
+			)
+
+			Expect(
+				[]string{
+					apps[0].TypeName(),
+					apps[1].TypeName(),
+				},
+			).To(
+				ConsistOf(
+					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-pkgs/first.App",
+					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-pkgs/second.App",
+				),
+			)
+
+			Expect(
+				[]configkit.EntityMessageNames{
+					apps[0].MessageNames(),
+					apps[1].MessageNames(),
+				},
+			).To(
+				ConsistOf(
+					configkit.EntityMessageNames{
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: configkit.HandlerSet{},
+					configkit.EntityMessageNames{
+						Produced: nil,
+						Consumed: nil,
+					},
+				),
+			)
+
+			Expect(
+				[]configkit.HandlerSet{
+					apps[0].Handlers(),
+					apps[1].Handlers(),
 				},
-			))
+			).To(
+				ConsistOf(
+					configkit.HandlerSet{},
+					configkit.HandlerSet{},
+				),
+			)
 		})
 	})
 
@@ -91,33 +127,67 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(2))
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(
+				[]configkit.Identity{
+					apps[0].Identity(),
+					apps[1].Identity(),
+				},
+			).To(
+				ConsistOf(
+					configkit.Identity{
 						Name: "<app-first>",
 						Key:  "4fec74a1-6ed4-46f4-8417-01e0910be8f1",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-single-pkg/apps.AppFirst",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
-				},
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+					configkit.Identity{
 						Name: "<app-second>",
 						Key:  "6e97d403-3cb8-4a59-a7ec-74e8e219a7bc",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-single-pkg/apps.AppSecond",
-					MessageNamesValue: configkit.EntityMessageNames{
+				),
+			)
+
+			Expect(
+				[]string{
+					apps[0].TypeName(),
+					apps[1].TypeName(),
+				},
+			).To(
+				ConsistOf(
+					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-single-pkg/apps.AppFirst",
+					"github.com/dogmatiq/configkit/static/testdata/apps/multiple-apps-in-single-pkg/apps.AppSecond",
+				),
+			)
+
+			Expect(
+				[]configkit.EntityMessageNames{
+					apps[0].MessageNames(),
+					apps[1].MessageNames(),
+				},
+			).To(
+				ConsistOf(
+					configkit.EntityMessageNames{
 						Produced: nil,
 						Consumed: nil,
 					},
-					HandlersValue: configkit.HandlerSet{},
+					configkit.EntityMessageNames{
+						Produced: nil,
+						Consumed: nil,
+					},
+				),
+			)
+
+			Expect(
+				[]configkit.HandlerSet{
+					apps[0].Handlers(),
+					apps[1].Handlers(),
 				},
-			))
+			).To(
+				ConsistOf(
+					configkit.HandlerSet{},
+					configkit.HandlerSet{},
+				),
+			)
 		})
 	})
 
@@ -133,20 +203,23 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 
 			apps := FromPackages(pkgs)
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(apps).To(HaveLen(1))
+			Expect(apps[0].Identity()).To(
+				Equal(
+					configkit.Identity{
 						Name: "<app>",
 						Key:  "b754902b-47c8-48fc-84d2-d920c9cbdaec",
 					},
-					TypeNameValue: "*github.com/dogmatiq/configkit/static/testdata/apps/pointer-receiver-app.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
+				),
+			)
+			Expect(apps[0].TypeName()).To(Equal("*github.com/dogmatiq/configkit/static/testdata/apps/pointer-receiver-app.App"))
+			Expect(apps[0].MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Produced: nil,
+					Consumed: nil,
 				},
 			))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -2,6 +2,8 @@ package static_test
 
 import (
 	"github.com/dogmatiq/configkit"
+	cfixtures "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/configkit/static"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -193,6 +195,37 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 					},
 				),
 			)
+		})
+	})
+
+	When("an application in the package has multiple handlers", func() {
+		It("returns all messages consumed or produced by all handlers", func() {
+			cfg := packages.Config{
+				Mode: packages.LoadAllSyntax,
+				Dir:  "testdata/apps/app-level-messages",
+			}
+
+			pkgs, err := packages.Load(&cfg, "./...")
+			Expect(err).NotTo(HaveOccurred())
+
+			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
+
+			Expect(apps[0].MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Consumed: message.NameRoles{
+						cfixtures.MessageATypeName: message.CommandRole,
+						cfixtures.MessageBTypeName: message.EventRole,
+						cfixtures.MessageCTypeName: message.EventRole,
+					},
+					Produced: message.NameRoles{
+						cfixtures.MessageBTypeName: message.EventRole,
+						cfixtures.MessageDTypeName: message.CommandRole,
+						cfixtures.MessageETypeName: message.TimeoutRole,
+						cfixtures.MessageFTypeName: message.EventRole,
+					},
+				},
+			))
 		})
 	})
 })

--- a/static/ident_test.go
+++ b/static/ident_test.go
@@ -32,10 +32,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/const-value-ident.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Produced: nil,
-					Consumed: nil,
-				},
+				configkit.EntityMessageNames{},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
@@ -64,10 +61,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/literal-value-ident.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Produced: nil,
-					Consumed: nil,
-				},
+				configkit.EntityMessageNames{},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
@@ -96,10 +90,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/variable-value-ident.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{
-					Produced: nil,
-					Consumed: nil,
-				},
+				configkit.EntityMessageNames{},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})

--- a/static/ident_test.go
+++ b/static/ident_test.go
@@ -2,7 +2,6 @@ package static_test
 
 import (
 	"github.com/dogmatiq/configkit"
-	"github.com/dogmatiq/configkit/internal/entity"
 	. "github.com/dogmatiq/configkit/static"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,21 +20,24 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(apps[0].Identity()).To(
+				Equal(
+					configkit.Identity{
 						Name: "<app>",
 						Key:  "04e12cf2-3c66-4414-9203-e045ddbe02c7",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/ident/const-value-ident.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
+				),
+			)
+			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/const-value-ident.App"))
+			Expect(apps[0].MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Produced: nil,
+					Consumed: nil,
 				},
 			))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 
@@ -50,21 +52,24 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(apps[0].Identity()).To(
+				Equal(
+					configkit.Identity{
 						Name: "<app>",
 						Key:  "9d0af85d-f506-4742-b676-ce87730bb1a0",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/ident/literal-value-ident.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
+				),
+			)
+			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/literal-value-ident.App"))
+			Expect(apps[0].MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Produced: nil,
+					Consumed: nil,
 				},
 			))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 
@@ -79,21 +84,24 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			apps := FromPackages(pkgs)
+			Expect(apps).To(HaveLen(1))
 
-			Expect(apps).To(ConsistOf(
-				&entity.Application{
-					IdentityValue: configkit.Identity{
+			Expect(apps[0].Identity()).To(
+				Equal(
+					configkit.Identity{
 						Name: "",
 						Key:  "",
 					},
-					TypeNameValue: "github.com/dogmatiq/configkit/static/testdata/ident/variable-value-ident.App",
-					MessageNamesValue: configkit.EntityMessageNames{
-						Produced: nil,
-						Consumed: nil,
-					},
-					HandlersValue: configkit.HandlerSet{},
+				),
+			)
+			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/variable-value-ident.App"))
+			Expect(apps[0].MessageNames()).To(Equal(
+				configkit.EntityMessageNames{
+					Produced: nil,
+					Consumed: nil,
 				},
 			))
+			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
 	})
 })

--- a/static/ident_test.go
+++ b/static/ident_test.go
@@ -2,6 +2,7 @@ package static_test
 
 import (
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
 	. "github.com/dogmatiq/configkit/static"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,10 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/const-value-ident.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{},
+				configkit.EntityMessageNames{
+					Produced: message.NameRoles{},
+					Consumed: message.NameRoles{},
+				},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
@@ -61,7 +65,10 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/literal-value-ident.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{},
+				configkit.EntityMessageNames{
+					Produced: message.NameRoles{},
+					Consumed: message.NameRoles{},
+				},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})
@@ -90,7 +97,10 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 			)
 			Expect(apps[0].TypeName()).To(Equal("github.com/dogmatiq/configkit/static/testdata/ident/variable-value-ident.App"))
 			Expect(apps[0].MessageNames()).To(Equal(
-				configkit.EntityMessageNames{},
+				configkit.EntityMessageNames{
+					Produced: message.NameRoles{},
+					Consumed: message.NameRoles{},
+				},
 			))
 			Expect(apps[0].Handlers()).To(Equal(configkit.HandlerSet{}))
 		})

--- a/static/testdata/apps/app-level-messages/aggregate.go
+++ b/static/testdata/apps/app-level-messages/aggregate.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Aggregate is an aggregate used for testing.
+type Aggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Aggregate) ApplyEvent(m dogma.Message) {}
+
+// AggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateHandler struct{}
+
+// New returns a new account instance.
+func (AggregateHandler) New() dogma.AggregateRoot {
+	return Aggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<aggregate>", "ef16c9d1-d7b6-4c99-a0e7-a59218e544fc")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ProducesEventType(fixtures.MessageB{})
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (AggregateHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (AggregateHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
+}

--- a/static/testdata/apps/app-level-messages/app.go
+++ b/static/testdata/apps/app-level-messages/app.go
@@ -1,0 +1,17 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<app-level-messages-app>", "2ecbd06f-6a1c-4dd8-81fc-23af38910f2b")
+
+	c.RegisterIntegration(IntegrationHandler{})
+	c.RegisterProjection(ProjectionHandler{})
+	c.RegisterAggregate(AggregateHandler{})
+	c.RegisterProcess(ProcessHandler{})
+}

--- a/static/testdata/apps/app-level-messages/integration.go
+++ b/static/testdata/apps/app-level-messages/integration.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Integration is an integration used for testing.
+type Integration struct{}
+
+// ApplyEvent updates the integration instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Integration) ApplyEvent(m dogma.Message) {}
+
+// IntegrationHandler is a test implementation of
+// dogma.IntegrationMessageHandler.
+type IntegrationHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (IntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
+	c.Identity("<integration>", "099b5b8d-9e04-422f-bcc3-bb0d451158c7")
+
+	c.ConsumesCommandType(fixtures.MessageA{})
+	c.ProducesEventType(fixtures.MessageF{})
+}
+
+// RouteCommandToInstance returns the ID of the integration instance that is
+// targetted by m.
+func (IntegrationHandler) RouteCommandToInstance(m dogma.Message) string {
+	return "<integration>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (IntegrationHandler) HandleCommand(
+	ctx context.Context,
+	s dogma.IntegrationCommandScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (IntegrationHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/apps/app-level-messages/process.go
+++ b/static/testdata/apps/app-level-messages/process.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Process is a process used for testing.
+type Process struct{}
+
+// ProcessHandler is a test implementation of dogma.ProcessMessageHandler.
+type ProcessHandler struct{}
+
+// New constructs a new process instance initialized with any default values and
+// returns the process root.
+func (ProcessHandler) New() dogma.ProcessRoot {
+	return Process{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (ProcessHandler) Configure(c dogma.ProcessConfigurer) {
+	c.Identity("<process>", "9c3d8ca7-1846-4793-8e11-bd43b1a98822")
+
+	c.ConsumesEventType(fixtures.MessageC{})
+	c.ProducesCommandType(fixtures.MessageD{})
+	c.SchedulesTimeoutType(fixtures.MessageE{})
+}
+
+// RouteEventToInstance returns the ID of the process instance that is
+// targeted by m.
+func (ProcessHandler) RouteEventToInstance(
+	ctx context.Context,
+	m dogma.Message,
+) (string, bool, error) {
+	return "<process>", true, nil
+}
+
+// HandleEvent handles an event message.
+func (ProcessHandler) HandleEvent(
+	ctx context.Context,
+	r dogma.ProcessRoot,
+	s dogma.ProcessEventScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// HandleTimeout handles a timeout message that has been scheduled with
+// ProcessScope.ScheduleTimeout().
+func (ProcessHandler) HandleTimeout(
+	ctx context.Context,
+	r dogma.ProcessRoot,
+	s dogma.ProcessTimeoutScope,
+	m dogma.Message,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (ProcessHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/apps/app-level-messages/projection.go
+++ b/static/testdata/apps/app-level-messages/projection.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Projection is a projection used for testing.
+type Projection struct{}
+
+// ProjectionHandler is a test implementation of dogma.ProjectionMessageHandler.
+type ProjectionHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (ProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
+	c.Identity("<projection>", "7a5090e0-7248-4a58-8d70-a5dfd8c8abe1")
+
+	c.ConsumesEventType(fixtures.MessageB{})
+	c.ConsumesEventType(fixtures.MessageC{})
+}
+
+// HandleEvent updates the projection to reflect the occurrence of an event.
+func (ProjectionHandler) HandleEvent(
+	ctx context.Context,
+	r, c, n []byte,
+	s dogma.ProjectionEventScope,
+	m dogma.Message,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+func (ProjectionHandler) ResourceVersion(
+	ctx context.Context,
+	r []byte,
+) ([]byte, error) {
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be
+// used in any future calls to HandleEvent().
+func (ProjectionHandler) CloseResource(ctx context.Context, r []byte) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (ProjectionHandler) TimeoutHint(m dogma.Message) time.Duration {
+	return 0
+}
+
+// Compact reduces the size of the projection's data.
+func (ProjectionHandler) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	return nil
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This change removes the type `entity.Application` declared in one of the `internal` subpackages from the `static` package  tests.

#### Why make this change?

This change is required to remove the internal type `entity.Application`  from the `static` package tests so that the latter become less dependent on the internal types that are less stable and more implementation-specific.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

This change relates to https://github.com/dogmatiq/configkit/issues/104.
