### PR TITLE
Unwrap partial handler implementations when obtained via an interface.

### DIFF
--- a/static/adaptor_test.go
+++ b/static/adaptor_test.go
@@ -21,6 +21,10 @@ var _ = Describe("func FromPackages() (adaptor function)", func() {
 			pkgs, err := packages.Load(&cfg, "./...")
 			Expect(err).NotTo(HaveOccurred())
 
+			for _, pkg := range pkgs {
+				Expect(pkg.Errors).To(BeEmpty())
+			}
+
 			apps := FromPackages(pkgs)
 			Expect(apps).To(HaveLen(1))
 			Expect(apps[0].Handlers().Aggregates()).To(HaveLen(1))

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -226,6 +226,12 @@ func addHandlersFromAdaptorFunc(
 		Type().(*types.Signature)
 
 	for _, arg := range call.Call.Args {
+		// If the argument to the adaptor function is an interface, use the
+		// concrete type instead.
+		if mi, ok := arg.(*ssa.MakeInterface); ok {
+			arg = mi.X
+		}
+
 		typ := arg.Type()
 
 		pkg, ok := tryPkgOfNamedType(typ)

--- a/static/testdata/handlers/adaptor/aggregate.go
+++ b/static/testdata/handlers/adaptor/aggregate.go
@@ -21,7 +21,14 @@ func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
 	c.ProducesEventType(fixtures.MessageD{})
 }
 
+// PartialAggregateMessageHandler is the subset of dogma.AggregateMessageHandler
+// that must be implemented for a type to be detected as a concrete
+// implementation.
+type PartialAggregateMessageHandler interface {
+	Configure(c dogma.AggregateConfigurer)
+}
+
 // AdaptAggregate adapts h to the dogma.AggregateMessageHandler interface.
-func AdaptAggregate(h AggregateHandler) dogma.AggregateMessageHandler {
+func AdaptAggregate(h PartialAggregateMessageHandler) dogma.AggregateMessageHandler {
 	panic("the implementation of this function is irrelevant to the analyzer")
 }

--- a/static/testdata/handlers/adaptor/integration.go
+++ b/static/testdata/handlers/adaptor/integration.go
@@ -21,7 +21,14 @@ func (IntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
 	c.ProducesEventType(fixtures.MessageD{})
 }
 
+// PartialIntegrationMessageHandler is the subset of
+// dogma.IntegrationMessageHandler that must be implemented for a type to be
+// detected as a concrete implementation.
+type PartialIntegrationMessageHandler interface {
+	Configure(c dogma.IntegrationConfigurer)
+}
+
 // AdaptIntegration adapts h to the dogma.IntegrationMessageHandler interface.
-func AdaptIntegration(h IntegrationHandler) dogma.IntegrationMessageHandler {
+func AdaptIntegration(h PartialIntegrationMessageHandler) dogma.IntegrationMessageHandler {
 	panic("the implementation of this function is irrelevant to the analyzer")
 }

--- a/static/testdata/handlers/adaptor/process.go
+++ b/static/testdata/handlers/adaptor/process.go
@@ -24,7 +24,14 @@ func (ProcessHandler) Configure(c dogma.ProcessConfigurer) {
 	c.SchedulesTimeoutType(fixtures.MessageF{})
 }
 
+// PartialProcessMessageHandler is the subset of dogma.ProcessMessageHandler
+// that must be implemented for a type to be detected as a concrete
+// implementation.
+type PartialProcessMessageHandler interface {
+	Configure(c dogma.ProcessConfigurer)
+}
+
 // AdaptProcess adapts h to the dogma.ProcessMessageHandler interface.
-func AdaptProcess(h ProcessHandler) dogma.ProcessMessageHandler {
+func AdaptProcess(h PartialProcessMessageHandler) dogma.ProcessMessageHandler {
 	panic("the implementation of this function is irrelevant to the analyzer")
 }

--- a/static/testdata/handlers/adaptor/projection.go
+++ b/static/testdata/handlers/adaptor/projection.go
@@ -18,7 +18,14 @@ func (ProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
 	c.ConsumesEventType(fixtures.MessageB{})
 }
 
+// PartialProjectionMessageHandler is the subset of
+// dogma.ProjectionMessageHandler that must be implemented for a type to be
+// detected as a concrete implementation.
+type PartialProjectionMessageHandler interface {
+	Configure(c dogma.ProjectionConfigurer)
+}
+
 // AdaptProjection adapts h to the dogma.ProjectionMessageHandler interface.
-func AdaptProjection(h ProjectionHandler) dogma.ProjectionMessageHandler {
+func AdaptProjection(h PartialProjectionMessageHandler) dogma.ProjectionMessageHandler {
 	panic("the implementation of this function is irrelevant to the analyzer")
 }


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR unwraps concrete types that are passed as interfaces to "adaptor" functions. 

#### Why make this change?

This is necessary to be able to detect projection handlers created via projectionkit, as each database specific sub-package of projectionkit defines its own interface for handlers, such as `sqlprojection.MessageHandler`.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

https://github.com/dogmatiq/configkit/issues/134
