### PR TITLE
Implement `Disable()` on handler configurers.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -29,8 +29,10 @@ type RichAggregate interface {
 // configuration related panic values to errors.
 func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 	cfg := &aggregate{
-		entity: entity{
-			rt: reflect.TypeOf(h),
+		handler: handler{
+			entity: entity{
+				rt: reflect.TypeOf(h),
+			},
 		},
 		impl: h,
 	}
@@ -40,6 +42,7 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 			entityConfigurer: entityConfigurer{
 				entity: &cfg.entity,
 			},
+			handler: &cfg.handler,
 		},
 	}
 
@@ -54,7 +57,7 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 
 // aggregate is an implementation of RichAggregate.
 type aggregate struct {
-	entity
+	handler
 
 	impl dogma.AggregateMessageHandler
 }

--- a/aggregate.go
+++ b/aggregate.go
@@ -32,9 +32,7 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 	return cfg
 }
 
-func fromAggregate(
-	h dogma.AggregateMessageHandler,
-) (*aggregate, *aggregateConfigurer) {
+func fromAggregate(h dogma.AggregateMessageHandler) (*aggregate, *aggregateConfigurer) {
 	cfg := &aggregate{
 		handler: handler{
 			entity: entity{

--- a/aggregate.go
+++ b/aggregate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 )
 
@@ -28,6 +27,14 @@ type RichAggregate interface {
 // It panics if the handler is configured incorrectly. Use Recover() to convert
 // configuration related panic values to errors.
 func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
+	cfg, c := fromAggregate(h)
+	c.mustValidate()
+	return cfg
+}
+
+func fromAggregate(
+	h dogma.AggregateMessageHandler,
+) (*aggregate, *aggregateConfigurer) {
 	cfg := &aggregate{
 		handler: handler{
 			entity: entity{
@@ -48,11 +55,7 @@ func FromAggregate(h dogma.AggregateMessageHandler) RichAggregate {
 
 	h.Configure(c)
 
-	c.validate()
-	c.mustConsume(message.CommandRole)
-	c.mustProduce(message.EventRole)
-
-	return cfg
+	return cfg, c
 }
 
 // aggregate is an implementation of RichAggregate.

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -34,7 +34,7 @@ var _ = Describe("func FromAggregate()", func() {
 	When("the configuration is valid", func() {
 		var cfg RichAggregate
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			cfg = FromAggregate(handler)
 		})
 
@@ -124,9 +124,31 @@ var _ = Describe("func FromAggregate()", func() {
 			})
 		})
 
+		Describe("func IsDisabled()", func() {
+			It("returns false", func() {
+				Expect(cfg.IsDisabled()).To(BeFalse())
+			})
+		})
+
 		Describe("func Handler()", func() {
 			It("returns the underlying handler", func() {
 				Expect(cfg.Handler()).To(BeIdenticalTo(handler))
+			})
+		})
+
+		When("the handler is disabled", func() {
+			BeforeEach(func() {
+				configure := handler.ConfigureFunc
+				handler.ConfigureFunc = func(c dogma.AggregateConfigurer) {
+					configure(c)
+					c.Disable()
+				}
+			})
+
+			Describe("func IsDisabled()", func() {
+				It("returns true", func() {
+					Expect(cfg.IsDisabled()).To(BeTrue())
+				})
 			})
 		})
 	})

--- a/aggregateconfigurer.go
+++ b/aggregateconfigurer.go
@@ -1,6 +1,9 @@
 package configkit
 
-import "github.com/dogmatiq/dogma"
+import (
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+)
 
 type aggregateConfigurer struct {
 	handlerConfigurer
@@ -10,4 +13,10 @@ func (c *aggregateConfigurer) Routes(routes ...dogma.AggregateRoute) {
 	for _, r := range routes {
 		c.route(r)
 	}
+}
+
+func (c *aggregateConfigurer) mustValidate() {
+	c.handlerConfigurer.mustValidate()
+	c.mustConsume(message.CommandRole)
+	c.mustProduce(message.EventRole)
 }

--- a/api/blackbox_test.go
+++ b/api/blackbox_test.go
@@ -77,6 +77,7 @@ var _ = Context("end-to-end tests", func() {
 							dogma.HandlesEvent[MessageE](),
 							dogma.HandlesEvent[MessageJ](),
 						)
+						c.Disable()
 					},
 				})
 			},

--- a/api/marshaling.go
+++ b/api/marshaling.go
@@ -82,7 +82,9 @@ func unmarshalApplication(in *configspec.Application) (configkit.Application, er
 
 // marshalHandler marshals a handler config to its protobuf representation.
 func marshalHandler(in configkit.Handler) (*configspec.Handler, error) {
-	out := &configspec.Handler{}
+	out := &configspec.Handler{
+		IsDisabled: in.IsDisabled(),
+	}
 
 	var err error
 	out.Identity, err = marshalIdentity(in.Identity())
@@ -122,6 +124,7 @@ func unmarshalHandler(in *configspec.Handler) (configkit.Handler, error) {
 			Produced: message.NameRoles{},
 			Consumed: message.NameRoles{},
 		},
+		IsDisabledValue: in.GetIsDisabled(),
 	}
 
 	var err error

--- a/application.go
+++ b/application.go
@@ -36,6 +36,12 @@ type RichApplication interface {
 // It panics if the application is configured incorrectly. Use Recover() to
 // convert configuration related panic values to errors.
 func FromApplication(a dogma.Application) RichApplication {
+	cfg, c := fromApplication(a)
+	c.mustValidate()
+	return cfg
+}
+
+func fromApplication(a dogma.Application) (*application, *applicationConfigurer) {
 	cfg := &application{
 		entity: entity{
 			rt: reflect.TypeOf(a),
@@ -52,9 +58,7 @@ func FromApplication(a dogma.Application) RichApplication {
 
 	a.Configure(c)
 
-	c.validate()
-
-	return cfg
+	return cfg, c
 }
 
 // IsApplicationEqual compares two applications for equality.

--- a/application_test.go
+++ b/application_test.go
@@ -68,6 +68,15 @@ var _ = Describe("func FromApplication()", func() {
 			},
 		}
 
+		disabled := &fixtures.ProjectionMessageHandler{
+			ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+				// Verify that disabled handlers with no identity / route
+				// configuration are excluded from the application
+				// configuration.
+				c.Disable()
+			},
+		}
+
 		app = &fixtures.Application{
 			ConfigureFunc: func(c dogma.ApplicationConfigurer) {
 				c.Identity("<app>", appKey)
@@ -75,6 +84,7 @@ var _ = Describe("func FromApplication()", func() {
 				c.RegisterProcess(process)
 				c.RegisterIntegration(integration)
 				c.RegisterProjection(projection)
+				c.RegisterProjection(disabled)
 			},
 		}
 	})

--- a/entityconfigurer.go
+++ b/entityconfigurer.go
@@ -12,11 +12,14 @@ import "github.com/dogmatiq/configkit/internal/validation"
 //   - [dogma.ProjectionConfigurer]
 type entityConfigurer struct {
 	// entity is the target entity to populate with the configuration values.
-	entity *entity
+	entity     *entity
+	configured bool
 }
 
 // Identity sets the entity's identity.
 func (c *entityConfigurer) Identity(n string, k string) {
+	c.configured = true
+
 	if !c.entity.ident.IsZero() {
 		validation.Panicf(
 			"%s is configured with multiple identities (%s and %s/%s), Identity() must be called exactly once within Configure()",
@@ -39,8 +42,12 @@ func (c *entityConfigurer) Identity(n string, k string) {
 	}
 }
 
-// validate panics if the configuration is invalid.
-func (c *entityConfigurer) validate() {
+func (c *entityConfigurer) isConfigured() bool {
+	return c.configured
+}
+
+// mustValidate panics if the configuration is invalid.
+func (c *entityConfigurer) mustValidate() {
 	if c.entity.ident.IsZero() {
 		validation.Panicf(
 			"%s is configured without an identity, Identity() must be called exactly once within Configure()",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/dogmatiq/dogma v0.13.1
 	github.com/dogmatiq/iago v0.4.0
-	github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159
+	github.com/dogmatiq/interopspec v0.5.4
 	github.com/emicklei/dot v1.6.2
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677
 	github.com/dogmatiq/iago v0.4.0
-	github.com/dogmatiq/interopspec v0.5.3
+	github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159
 	github.com/emicklei/dot v1.6.2
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo v1.16.5
@@ -25,7 +25,7 @@ require (
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/protobuf v1.34.1 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dogmatiq/configkit
 go 1.21
 
 require (
-	github.com/dogmatiq/dogma v0.13.0
+	github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677
 	github.com/dogmatiq/iago v0.4.0
 	github.com/dogmatiq/interopspec v0.5.3
 	github.com/emicklei/dot v1.6.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dogmatiq/configkit
 go 1.21
 
 require (
-	github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677
+	github.com/dogmatiq/dogma v0.13.1
 	github.com/dogmatiq/iago v0.4.0
 	github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159
 	github.com/emicklei/dot v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,12 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677 h1:2DDD3+89VQre3EOvkJL1syN5EUXNU06uAkXE5/fsaBU=
-github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
 github.com/dogmatiq/dogma v0.13.1 h1:b1nsqYNmICEG2egvZ43K8w04Jma+MWYL6yF5Ad12y9o=
 github.com/dogmatiq/dogma v0.13.1/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
-github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159 h1:kcIQqg9QMoFALL74TaAMFEo+rAGw/wTxGZJWr73MTag=
-github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159/go.mod h1:JL0QFXBTRGH+RgQqExhEUdhtv5Vn802w43RxKQbk8Co=
+github.com/dogmatiq/interopspec v0.5.4 h1:klyGPy16zUKJartJIJOBZ4JrQ4LxFiY3wgzFTTiNlDk=
+github.com/dogmatiq/interopspec v0.5.4/go.mod h1:JL0QFXBTRGH+RgQqExhEUdhtv5Vn802w43RxKQbk8Co=
 github.com/emicklei/dot v1.6.2 h1:08GN+DD79cy/tzN6uLCT84+2Wk9u+wvqP+Hkx/dIR8A=
 github.com/emicklei/dot v1.6.2/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677 h1:2DDD3+89VQre3
 github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
-github.com/dogmatiq/interopspec v0.5.3 h1:AES184nLWcek8/vafykZJLmm59NlRiYiC40Tll8hEeg=
-github.com/dogmatiq/interopspec v0.5.3/go.mod h1:3RdRwvDzgqLwemSieP+YAvKp3CMP0rYwZFl5tpmn6DI=
+github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159 h1:kcIQqg9QMoFALL74TaAMFEo+rAGw/wTxGZJWr73MTag=
+github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159/go.mod h1:JL0QFXBTRGH+RgQqExhEUdhtv5Vn802w43RxKQbk8Co=
 github.com/emicklei/dot v1.6.2 h1:08GN+DD79cy/tzN6uLCT84+2Wk9u+wvqP+Hkx/dIR8A=
 github.com/emicklei/dot v1.6.2/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -110,8 +110,8 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
-google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677 h1:2DDD3+89VQre3EOvkJL1syN5EUXNU06uAkXE5/fsaBU=
 github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
+github.com/dogmatiq/dogma v0.13.1 h1:b1nsqYNmICEG2egvZ43K8w04Jma+MWYL6yF5Ad12y9o=
+github.com/dogmatiq/dogma v0.13.1/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/dogmatiq/interopspec v0.5.4-0.20240709214918-063ff420b159 h1:kcIQqg9QMoFALL74TaAMFEo+rAGw/wTxGZJWr73MTag=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dogmatiq/dogma v0.13.0 h1:MKk9MHErGKD53Y+43I4fcoPZMQjX0N2DUZEc4rLp+Hk=
-github.com/dogmatiq/dogma v0.13.0/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
+github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677 h1:2DDD3+89VQre3EOvkJL1syN5EUXNU06uAkXE5/fsaBU=
+github.com/dogmatiq/dogma v0.13.1-0.20240708211023-af9214272677/go.mod h1:9lyVA+6V2+E/exV0IrBOrkUiyFwIATEhv+b0vnB2umQ=
 github.com/dogmatiq/iago v0.4.0 h1:57nZqVT34IZxtCZEW/RFif7DNUEjMXgevfr/Mmd0N8I=
 github.com/dogmatiq/iago v0.4.0/go.mod h1:fishMWBtzYcjgis6d873VTv9kFm/wHYLOzOyO9ECBDc=
 github.com/dogmatiq/interopspec v0.5.3 h1:AES184nLWcek8/vafykZJLmm59NlRiYiC40Tll8hEeg=

--- a/handler.go
+++ b/handler.go
@@ -6,6 +6,9 @@ type Handler interface {
 
 	// HandlerType returns the type of handler.
 	HandlerType() HandlerType
+
+	// IsDisabled returns true if the handler is disabled.
+	IsDisabled() bool
 }
 
 // RichHandler is a specialization of the Handler interface that exposes
@@ -15,6 +18,9 @@ type RichHandler interface {
 
 	// HandlerType returns the type of handler.
 	HandlerType() HandlerType
+
+	// IsDisabled returns true if the handler is disabled.
+	IsDisabled() bool
 }
 
 // IsHandlerEqual compares two handlers for equality.
@@ -37,4 +43,13 @@ func IsHandlerEqual(a, b Handler) bool {
 		a.TypeName() == b.TypeName() &&
 		a.HandlerType() == b.HandlerType() &&
 		a.MessageNames().IsEqual(b.MessageNames())
+}
+
+type handler struct {
+	entity
+	isDisabled bool
+}
+
+func (h *handler) IsDisabled() bool {
+	return h.isDisabled
 }

--- a/handler.go
+++ b/handler.go
@@ -42,6 +42,7 @@ func IsHandlerEqual(a, b Handler) bool {
 	return a.Identity() == b.Identity() &&
 		a.TypeName() == b.TypeName() &&
 		a.HandlerType() == b.HandlerType() &&
+		a.IsDisabled() == b.IsDisabled() &&
 		a.MessageNames().IsEqual(b.MessageNames())
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -86,6 +86,20 @@ var _ = Describe("func IsHandlerEqual()", func() {
 			}),
 		),
 		Entry(
+			"disabled state differs",
+			FromAggregate(&fixtures.AggregateMessageHandler{
+				ConfigureFunc: func(c dogma.AggregateConfigurer) {
+					c.Identity("<name>", aggregateKey)
+					c.Routes(
+						dogma.HandlesCommand[fixtures.MessageA](),
+						dogma.HandlesCommand[fixtures.MessageB](),
+						dogma.RecordsEvent[fixtures.MessageE](),
+					)
+					c.Disable()
+				},
+			}),
+		),
+		Entry(
 			"messages differ",
 			FromAggregate(&fixtures.AggregateMessageHandler{
 				ConfigureFunc: func(c dogma.AggregateConfigurer) {

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -19,6 +19,7 @@ import (
 //   - [dogma.ProjectionConfigurer]
 type handlerConfigurer struct {
 	entityConfigurer
+	handler *handler
 }
 
 func (c *handlerConfigurer) route(r dogma.Route) {
@@ -154,4 +155,8 @@ func (c *handlerConfigurer) mustProduce(r message.Role) {
 		r,
 		route,
 	)
+}
+
+func (c *handlerConfigurer) Disable(...dogma.DisableOption) {
+	c.handler.isDisabled = true
 }

--- a/handlerconfigurer.go
+++ b/handlerconfigurer.go
@@ -22,7 +22,13 @@ type handlerConfigurer struct {
 	handler *handler
 }
 
+func (c *handlerConfigurer) Disable(...dogma.DisableOption) {
+	c.handler.isDisabled = true
+}
+
 func (c *handlerConfigurer) route(r dogma.Route) {
+	c.configured = true
+
 	switch r := r.(type) {
 	case dogma.HandlesCommandRoute:
 		c.consumes(r.Type, message.CommandRole, "HandlesCommand")
@@ -155,8 +161,4 @@ func (c *handlerConfigurer) mustProduce(r message.Role) {
 		r,
 		route,
 	)
-}
-
-func (c *handlerConfigurer) Disable(...dogma.DisableOption) {
-	c.handler.isDisabled = true
 }

--- a/integration.go
+++ b/integration.go
@@ -29,8 +29,10 @@ type RichIntegration interface {
 // configuration related panic values to errors.
 func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 	cfg := &integration{
-		entity: entity{
-			rt: reflect.TypeOf(h),
+		handler: handler{
+			entity: entity{
+				rt: reflect.TypeOf(h),
+			},
 		},
 		impl: h,
 	}
@@ -40,6 +42,7 @@ func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 			entityConfigurer: entityConfigurer{
 				entity: &cfg.entity,
 			},
+			handler: &cfg.handler,
 		},
 	}
 
@@ -53,7 +56,7 @@ func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 
 // integration is an implementation of RichIntegration.
 type integration struct {
-	entity
+	handler
 
 	impl dogma.IntegrationMessageHandler
 }

--- a/integration.go
+++ b/integration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 )
 
@@ -28,6 +27,12 @@ type RichIntegration interface {
 // It panics if the handler is configured incorrectly. Use Recover() to convert
 // configuration related panic values to errors.
 func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
+	cfg, c := fromIntegration(h)
+	c.mustValidate()
+	return cfg
+}
+
+func fromIntegration(h dogma.IntegrationMessageHandler) (*integration, *integrationConfigurer) {
 	cfg := &integration{
 		handler: handler{
 			entity: entity{
@@ -48,10 +53,7 @@ func FromIntegration(h dogma.IntegrationMessageHandler) RichIntegration {
 
 	h.Configure(c)
 
-	c.validate()
-	c.mustConsume(message.CommandRole)
-
-	return cfg
+	return cfg, c
 }
 
 // integration is an implementation of RichIntegration.

--- a/integration_test.go
+++ b/integration_test.go
@@ -34,7 +34,7 @@ var _ = Describe("func FromIntegration()", func() {
 	When("the configuration is valid", func() {
 		var cfg RichIntegration
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			cfg = FromIntegration(handler)
 		})
 
@@ -127,6 +127,22 @@ var _ = Describe("func FromIntegration()", func() {
 		Describe("func Handler()", func() {
 			It("returns the underlying handler", func() {
 				Expect(cfg.Handler()).To(BeIdenticalTo(handler))
+			})
+		})
+
+		When("the handler is disabled", func() {
+			BeforeEach(func() {
+				configure := handler.ConfigureFunc
+				handler.ConfigureFunc = func(c dogma.IntegrationConfigurer) {
+					configure(c)
+					c.Disable()
+				}
+			})
+
+			Describe("func IsDisabled()", func() {
+				It("returns true", func() {
+					Expect(cfg.IsDisabled()).To(BeTrue())
+				})
 			})
 		})
 

--- a/integrationconfigurer.go
+++ b/integrationconfigurer.go
@@ -1,6 +1,9 @@
 package configkit
 
-import "github.com/dogmatiq/dogma"
+import (
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+)
 
 type integrationConfigurer struct {
 	handlerConfigurer
@@ -10,4 +13,9 @@ func (c *integrationConfigurer) Routes(routes ...dogma.IntegrationRoute) {
 	for _, r := range routes {
 		c.route(r)
 	}
+}
+
+func (c *integrationConfigurer) mustValidate() {
+	c.handlerConfigurer.mustValidate()
+	c.mustConsume(message.CommandRole)
 }

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -45,6 +45,7 @@ type Handler struct {
 	TypeNameValue     string
 	MessageNamesValue configkit.EntityMessageNames
 	HandlerTypeValue  configkit.HandlerType
+	IsDisabledValue   bool
 }
 
 // Identity returns the identity of the entity.
@@ -65,6 +66,11 @@ func (h *Handler) MessageNames() configkit.EntityMessageNames {
 // HandlerType returns the type of handler.
 func (h *Handler) HandlerType() configkit.HandlerType {
 	return h.HandlerTypeValue
+}
+
+// IsDisabled returns true if the handler is disabled.
+func (h *Handler) IsDisabled() bool {
+	return h.IsDisabledValue
 }
 
 // AcceptVisitor calls the appropriate method on v for this entity type.

--- a/internal/entity/entity_test.go
+++ b/internal/entity/entity_test.go
@@ -99,24 +99,24 @@ var _ = Describe("type Application", func() {
 })
 
 var _ = Describe("type Handler", func() {
-	var hnd *Handler
+	var handler *Handler
 
 	BeforeEach(func() {
-		hnd = &Handler{}
+		handler = &Handler{}
 	})
 
 	Describe("func Identity()", func() {
 		It("returns the value of .IdentityValue field", func() {
 			i := configkit.MustNewIdentity("<name>", "7502b306-8e9e-4f23-99ba-00c5bf138de5")
-			hnd.IdentityValue = i
-			Expect(hnd.Identity()).To(Equal(i))
+			handler.IdentityValue = i
+			Expect(handler.Identity()).To(Equal(i))
 		})
 	})
 
 	Describe("func TypeName()", func() {
 		It("returns the value of .TypeNameValue field", func() {
-			hnd.TypeNameValue = reflect.TypeOf(hnd).String()
-			Expect(hnd.TypeName()).To(Equal("*entity.Handler"))
+			handler.TypeNameValue = reflect.TypeOf(handler).String()
+			Expect(handler.TypeName()).To(Equal("*entity.Handler"))
 		})
 	})
 
@@ -131,15 +131,22 @@ var _ = Describe("type Handler", func() {
 				},
 			}
 
-			hnd.MessageNamesValue = m
-			Expect(hnd.MessageNames()).To(Equal(m))
+			handler.MessageNamesValue = m
+			Expect(handler.MessageNames()).To(Equal(m))
 		})
 	})
 
 	Describe("func HandlerType()", func() {
 		It("returns the value of .HandlerTypeValue field", func() {
-			hnd.HandlerTypeValue = configkit.AggregateHandlerType
-			Expect(hnd.HandlerType()).To(Equal(configkit.AggregateHandlerType))
+			handler.HandlerTypeValue = configkit.AggregateHandlerType
+			Expect(handler.HandlerType()).To(Equal(configkit.AggregateHandlerType))
+		})
+	})
+
+	Describe("func IsDisabled()", func() {
+		It("returns the value of .IsDisabledValue field", func() {
+			handler.IsDisabledValue = true
+			Expect(handler.IsDisabled()).To(BeTrue())
 		})
 	})
 
@@ -152,64 +159,64 @@ var _ = Describe("type Handler", func() {
 
 		When("the handler is an aggregate", func() {
 			BeforeEach(func() {
-				hnd.HandlerTypeValue = configkit.AggregateHandlerType
+				handler.HandlerTypeValue = configkit.AggregateHandlerType
 			})
 
 			It("calls the correct visitor method", func() {
 				visitor.VisitAggregateFunc = func(_ context.Context, h configkit.Aggregate) error {
-					Expect(h).To(Equal(hnd))
+					Expect(h).To(Equal(handler))
 					return errors.New("<error>")
 				}
 
-				err := hnd.AcceptVisitor(context.Background(), visitor)
+				err := handler.AcceptVisitor(context.Background(), visitor)
 				Expect(err).To(Equal(err))
 			})
 		})
 
 		When("the handler is a process", func() {
 			BeforeEach(func() {
-				hnd.HandlerTypeValue = configkit.ProcessHandlerType
+				handler.HandlerTypeValue = configkit.ProcessHandlerType
 			})
 
 			It("calls the correct visitor method", func() {
 				visitor.VisitProcessFunc = func(_ context.Context, h configkit.Process) error {
-					Expect(h).To(Equal(hnd))
+					Expect(h).To(Equal(handler))
 					return errors.New("<error>")
 				}
 
-				err := hnd.AcceptVisitor(context.Background(), visitor)
+				err := handler.AcceptVisitor(context.Background(), visitor)
 				Expect(err).To(Equal(err))
 			})
 		})
 
 		When("the handler is an integration", func() {
 			BeforeEach(func() {
-				hnd.HandlerTypeValue = configkit.IntegrationHandlerType
+				handler.HandlerTypeValue = configkit.IntegrationHandlerType
 			})
 
 			It("calls the correct visitor method", func() {
 				visitor.VisitIntegrationFunc = func(_ context.Context, h configkit.Integration) error {
-					Expect(h).To(Equal(hnd))
+					Expect(h).To(Equal(handler))
 					return errors.New("<error>")
 				}
 
-				err := hnd.AcceptVisitor(context.Background(), visitor)
+				err := handler.AcceptVisitor(context.Background(), visitor)
 				Expect(err).To(Equal(err))
 			})
 		})
 
 		When("the handler is a projection", func() {
 			BeforeEach(func() {
-				hnd.HandlerTypeValue = configkit.ProjectionHandlerType
+				handler.HandlerTypeValue = configkit.ProjectionHandlerType
 			})
 
 			It("calls the correct visitor method", func() {
 				visitor.VisitProjectionFunc = func(_ context.Context, h configkit.Projection) error {
-					Expect(h).To(Equal(hnd))
+					Expect(h).To(Equal(handler))
 					return errors.New("<error>")
 				}
 
-				err := hnd.AcceptVisitor(context.Background(), visitor)
+				err := handler.AcceptVisitor(context.Background(), visitor)
 				Expect(err).To(Equal(err))
 			})
 		})

--- a/process.go
+++ b/process.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 )
 
@@ -28,6 +27,12 @@ type RichProcess interface {
 // It panics if the handler is configured incorrectly. Use Recover() to convert
 // configuration related panic values to errors.
 func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
+	cfg, c := fromProcess(h)
+	c.mustValidate()
+	return cfg
+}
+
+func fromProcess(h dogma.ProcessMessageHandler) (*process, *processConfigurer) {
 	cfg := &process{
 		handler: handler{
 			entity: entity{
@@ -48,11 +53,7 @@ func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 
 	h.Configure(c)
 
-	c.validate()
-	c.mustConsume(message.EventRole)
-	c.mustProduce(message.CommandRole)
-
-	return cfg
+	return cfg, c
 }
 
 // process is an implementation of RichProcess.

--- a/process.go
+++ b/process.go
@@ -29,8 +29,10 @@ type RichProcess interface {
 // configuration related panic values to errors.
 func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 	cfg := &process{
-		entity: entity{
-			rt: reflect.TypeOf(h),
+		handler: handler{
+			entity: entity{
+				rt: reflect.TypeOf(h),
+			},
 		},
 		impl: h,
 	}
@@ -40,6 +42,7 @@ func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 			entityConfigurer: entityConfigurer{
 				entity: &cfg.entity,
 			},
+			handler: &cfg.handler,
 		},
 	}
 
@@ -54,7 +57,7 @@ func FromProcess(h dogma.ProcessMessageHandler) RichProcess {
 
 // process is an implementation of RichProcess.
 type process struct {
-	entity
+	handler
 
 	impl dogma.ProcessMessageHandler
 }

--- a/process_test.go
+++ b/process_test.go
@@ -35,7 +35,7 @@ var _ = Describe("func FromProcess()", func() {
 	When("the configuration is valid", func() {
 		var cfg RichProcess
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			cfg = FromProcess(handler)
 		})
 
@@ -132,6 +132,22 @@ var _ = Describe("func FromProcess()", func() {
 		Describe("func Handler()", func() {
 			It("returns the underlying handler", func() {
 				Expect(cfg.Handler()).To(BeIdenticalTo(handler))
+			})
+		})
+
+		When("the handler is disabled", func() {
+			BeforeEach(func() {
+				configure := handler.ConfigureFunc
+				handler.ConfigureFunc = func(c dogma.ProcessConfigurer) {
+					configure(c)
+					c.Disable()
+				}
+			})
+
+			Describe("func IsDisabled()", func() {
+				It("returns true", func() {
+					Expect(cfg.IsDisabled()).To(BeTrue())
+				})
 			})
 		})
 	})

--- a/processconfigurer.go
+++ b/processconfigurer.go
@@ -1,6 +1,9 @@
 package configkit
 
-import "github.com/dogmatiq/dogma"
+import (
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+)
 
 type processConfigurer struct {
 	handlerConfigurer
@@ -10,4 +13,10 @@ func (c *processConfigurer) Routes(routes ...dogma.ProcessRoute) {
 	for _, r := range routes {
 		c.route(r)
 	}
+}
+
+func (c *processConfigurer) mustValidate() {
+	c.handlerConfigurer.mustValidate()
+	c.mustConsume(message.EventRole)
+	c.mustProduce(message.CommandRole)
 }

--- a/projection.go
+++ b/projection.go
@@ -32,8 +32,10 @@ type RichProjection interface {
 // configuration related panic values to errors.
 func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 	cfg := &projection{
-		entity: entity{
-			rt: reflect.TypeOf(h),
+		handler: handler{
+			entity: entity{
+				rt: reflect.TypeOf(h),
+			},
 		},
 		impl:           h,
 		deliveryPolicy: dogma.UnicastProjectionDeliveryPolicy{},
@@ -44,6 +46,7 @@ func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 			entityConfigurer: entityConfigurer{
 				entity: &cfg.entity,
 			},
+			handler: &cfg.handler,
 		},
 	}
 
@@ -61,7 +64,7 @@ func FromProjection(h dogma.ProjectionMessageHandler) RichProjection {
 
 // projection is an implementation of RichProjection.
 type projection struct {
-	entity
+	handler
 
 	impl           dogma.ProjectionMessageHandler
 	deliveryPolicy dogma.ProjectionDeliveryPolicy

--- a/projection_test.go
+++ b/projection_test.go
@@ -36,7 +36,7 @@ var _ = Describe("func FromProjection()", func() {
 	When("the configuration is valid", func() {
 		var cfg RichProjection
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			cfg = FromProjection(handler)
 		})
 
@@ -135,6 +135,22 @@ var _ = Describe("func FromProjection()", func() {
 		Describe("func Handler()", func() {
 			It("returns the underlying handler", func() {
 				Expect(cfg.Handler()).To(BeIdenticalTo(handler))
+			})
+		})
+
+		When("the handler is disabled", func() {
+			BeforeEach(func() {
+				configure := handler.ConfigureFunc
+				handler.ConfigureFunc = func(c dogma.ProjectionConfigurer) {
+					configure(c)
+					c.Disable()
+				}
+			})
+
+			Describe("func IsDisabled()", func() {
+				It("returns true", func() {
+					Expect(cfg.IsDisabled()).To(BeTrue())
+				})
 			})
 		})
 	})

--- a/projectionconfigurer.go
+++ b/projectionconfigurer.go
@@ -2,12 +2,13 @@ package configkit
 
 import (
 	"github.com/dogmatiq/configkit/internal/validation"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 )
 
 type projectionConfigurer struct {
 	handlerConfigurer
-	deliveryPolicy dogma.ProjectionDeliveryPolicy
+	projection *projection
 }
 
 func (c *projectionConfigurer) Routes(routes ...dogma.ProjectionRoute) {
@@ -17,9 +18,16 @@ func (c *projectionConfigurer) Routes(routes ...dogma.ProjectionRoute) {
 }
 
 func (c *projectionConfigurer) DeliveryPolicy(p dogma.ProjectionDeliveryPolicy) {
+	c.configured = true
+
 	if p == nil {
 		validation.Panicf("delivery policy must not be nil")
 	}
 
-	c.deliveryPolicy = p
+	c.projection.deliveryPolicy = p
+}
+
+func (c *projectionConfigurer) mustValidate() {
+	c.handlerConfigurer.mustValidate()
+	c.mustConsume(message.EventRole)
 }

--- a/string.go
+++ b/string.go
@@ -60,13 +60,24 @@ func (s *stringer) VisitApplication(ctx context.Context, cfg Application) error 
 func (s *stringer) visitHandler(cfg Handler) error {
 	id := cfg.Identity()
 
+	var flags []string
+	if cfg.IsDisabled() {
+		flags = append(flags, "disabled")
+	}
+
+	flagString := ""
+	if len(flags) > 0 {
+		flagString = " [" + strings.Join(flags, ", ") + "]"
+	}
+
 	must.Fprintf(
 		s.w,
-		"%s %s (%s) %s\n",
+		"%s %s (%s) %s%s\n",
 		cfg.HandlerType(),
 		id.Name,
 		id.Key,
 		cfg.TypeName(),
+		flagString,
 	)
 
 	for _, p := range sortNameRoles(cfg.MessageNames().Consumed) {

--- a/string_test.go
+++ b/string_test.go
@@ -56,6 +56,7 @@ var _ = Describe("func ToString()", func() {
 							dogma.HandlesEvent[fixtures.MessageE](),
 							dogma.HandlesEvent[fixtures.MessageJ](),
 						)
+						c.Disable()
 					},
 				})
 			},
@@ -80,7 +81,7 @@ var _ = Describe("func ToString()", func() {
 		expected += "        executes github.com/dogmatiq/dogma/fixtures.MessageC?\n"
 		expected += "        schedules github.com/dogmatiq/dogma/fixtures.MessageT@\n"
 		expected += "\n"
-		expected += "    - projection <projection> (70fdf7fa-4b24-448d-bd29-7ecc71d18c56) *github.com/dogmatiq/dogma/fixtures.ProjectionMessageHandler\n"
+		expected += "    - projection <projection> (70fdf7fa-4b24-448d-bd29-7ecc71d18c56) *github.com/dogmatiq/dogma/fixtures.ProjectionMessageHandler [disabled]\n"
 		expected += "        handles github.com/dogmatiq/dogma/fixtures.MessageE!\n"
 		expected += "        handles github.com/dogmatiq/dogma/fixtures.MessageJ!\n"
 


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds an `IsDisabled()` method to the `Handler` and `RichHandler` interfaces, the return value of which is driven by calls to the `Disable()` method on Dogma's handler configurer interfaces (`AggregateConfigurer`, etc).

#### Why make this change?

I wanted to prototype this before merging dogmatiq/dogma#162

#### Is there anything you are unsure about?

I haven't looked into adding support for `Disable()` to the static analysis system. ~I also haven't added support to the interopspec config API.~

#### What issues does this relate to?

- dogmatiq/dogma#162
