### PR TITLE
Add `ToProto()` and `FromProto()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Added `ToProto()` and `FromProto()` to convert application configurations to
+  and from their protocol buffers representations.
+
 ## [0.13.2] - 2024-08-12
 
 ### Fixed

--- a/api/client.go
+++ b/api/client.go
@@ -35,7 +35,7 @@ func (c *Client) ListApplications(
 
 	var configs []configkit.Application
 	for _, in := range res.GetApplications() {
-		out, err := unmarshalApplication(in)
+		out, err := configkit.FromProto(in)
 		if err != nil {
 			return nil, err
 		}

--- a/api/server.go
+++ b/api/server.go
@@ -20,7 +20,7 @@ func NewServer(apps ...configkit.Application) *Server {
 	s := &Server{}
 
 	for _, in := range apps {
-		out, err := marshalApplication(in)
+		out, err := configkit.ToProto(in)
 		if err != nil {
 			panic(err)
 		}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,6 +1,7 @@
-package api
+package api_test
 
 import (
+	. "github.com/dogmatiq/configkit/api"
 	"github.com/dogmatiq/configkit/internal/entity"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/entity/doc.go
+++ b/internal/entity/doc.go
@@ -1,0 +1,5 @@
+// Package entity provides internal implementations of the entities defined in
+// the configkit package.
+//
+// deprecated: Packages should define their own implementations instead.
+package entity

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,48 +1,46 @@
-package api
+package configkit
 
 import (
-	"github.com/dogmatiq/configkit"
-	"github.com/dogmatiq/configkit/internal/entity"
 	"github.com/dogmatiq/configkit/message"
-	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/interopspec/configspec"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("func marshalApplication()", func() {
-	var app *entity.Application
+var _ = Describe("func ToProto()", func() {
+	var app *unmarshaledApplication
 
 	BeforeEach(func() {
-		app = &entity.Application{
-			IdentityValue:     configkit.MustNewIdentity("<name>", "28c19ec0-a32f-4479-bb1d-02887e90077c"),
-			TypeNameValue:     "<app type>",
-			MessageNamesValue: configkit.EntityMessageNames{},
-			HandlersValue:     configkit.HandlerSet{},
+		app = &unmarshaledApplication{
+			ident:    MustNewIdentity("<name>", "28c19ec0-a32f-4479-bb1d-02887e90077c"),
+			typeName: "<app type>",
+			names:    EntityMessageNames{},
+			handlers: HandlerSet{},
 		}
 	})
 
 	It("returns an error if the identity is invalid", func() {
-		app.IdentityValue.Name = ""
-		_, err := marshalApplication(app)
+		app.ident.Name = ""
+		_, err := ToProto(app)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the type name is empty", func() {
-		app.TypeNameValue = ""
-		_, err := marshalApplication(app)
+		app.typeName = ""
+		_, err := ToProto(app)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if one of the handlers is invalid", func() {
-		app.HandlersValue.Add(&entity.Handler{})
-		_, err := marshalApplication(app)
+		app.handlers.Add(&unmarshaledHandler{})
+		_, err := ToProto(app)
 		Expect(err).Should(HaveOccurred())
 	})
 })
 
-var _ = Describe("func unmarshalApplication()", func() {
+var _ = Describe("func FromProto()", func() {
 	var app *configspec.Application
 
 	BeforeEach(func() {
@@ -54,77 +52,77 @@ var _ = Describe("func unmarshalApplication()", func() {
 
 	It("returns an error if the identity is invalid", func() {
 		app.Identity.Name = ""
-		_, err := unmarshalApplication(app)
+		_, err := FromProto(app)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the type name is empty", func() {
 		app.GoType = ""
-		_, err := unmarshalApplication(app)
+		_, err := FromProto(app)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if one of the handlers is invalid", func() {
 		app.Handlers = append(app.Handlers, &configspec.Handler{})
-		_, err := unmarshalApplication(app)
+		_, err := FromProto(app)
 		Expect(err).Should(HaveOccurred())
 	})
 })
 
 var _ = Describe("func marshalHandler()", func() {
-	var hnd *entity.Handler
+	var handler *unmarshaledHandler
 
 	BeforeEach(func() {
-		hnd = &entity.Handler{
-			IdentityValue:     configkit.MustNewIdentity("<name>", "26c19bed-f9e8-45b1-8f60-746f7ca6ef36"),
-			TypeNameValue:     "github.com/dogmatiq/dogma/fixtures.MessageA",
-			MessageNamesValue: configkit.EntityMessageNames{},
-			HandlerTypeValue:  configkit.AggregateHandlerType,
+		handler = &unmarshaledHandler{
+			ident:       MustNewIdentity("<name>", "26c19bed-f9e8-45b1-8f60-746f7ca6ef36"),
+			typeName:    "github.com/dogmatiq/dogma/fixtures.MessageA",
+			names:       EntityMessageNames{},
+			handlerType: AggregateHandlerType,
 		}
 	})
 
 	It("returns an error if the identity is invalid", func() {
-		hnd.IdentityValue.Name = ""
-		_, err := marshalHandler(hnd)
+		handler.ident.Name = ""
+		_, err := marshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the type name is empty", func() {
-		hnd.TypeNameValue = ""
-		_, err := marshalHandler(hnd)
+		handler.typeName = ""
+		_, err := marshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the handler type is invalid", func() {
-		hnd.HandlerTypeValue = "<unknown>"
-		_, err := marshalHandler(hnd)
+		handler.handlerType = "<unknown>"
+		_, err := marshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the consumed name/roles are invalid", func() {
-		hnd.MessageNamesValue.Consumed = message.NameRoles{
-			message.NameOf(MessageA{}): "<unknown>",
+		handler.names.Consumed = message.NameRoles{
+			message.NameOf(fixtures.MessageA{}): "<unknown>",
 		}
 
-		_, err := marshalHandler(hnd)
+		_, err := marshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the produced name/roles are invalid", func() {
-		hnd.MessageNamesValue.Produced = message.NameRoles{
-			message.NameOf(MessageA{}): "<unknown>",
+		handler.names.Produced = message.NameRoles{
+			message.NameOf(fixtures.MessageA{}): "<unknown>",
 		}
 
-		_, err := marshalHandler(hnd)
+		_, err := marshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 })
 
 var _ = Describe("func unmarshalHandler()", func() {
-	var hnd *configspec.Handler
+	var handler *configspec.Handler
 
 	BeforeEach(func() {
-		hnd = &configspec.Handler{
+		handler = &configspec.Handler{
 			Identity:         &configspec.Identity{Name: "<name>", Key: "71976ec1-39c6-4f7e-b16f-632ec307e35b"},
 			GoType:           "<handler type>",
 			Type:             configspec.HandlerType_AGGREGATE,
@@ -134,38 +132,38 @@ var _ = Describe("func unmarshalHandler()", func() {
 	})
 
 	It("returns an error if the identity is invalid", func() {
-		hnd.Identity.Name = ""
-		_, err := unmarshalHandler(hnd)
+		handler.Identity.Name = ""
+		_, err := unmarshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the type name is empty", func() {
-		hnd.GoType = ""
-		_, err := unmarshalHandler(hnd)
+		handler.GoType = ""
+		_, err := unmarshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the handler type is invalid", func() {
-		hnd.Type = configspec.HandlerType_UNKNOWN_HANDLER_TYPE
-		_, err := unmarshalHandler(hnd)
+		handler.Type = configspec.HandlerType_UNKNOWN_HANDLER_TYPE
+		_, err := unmarshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the consumed messages are invalid", func() {
-		hnd.ConsumedMessages = map[string]configspec.MessageRole{
+		handler.ConsumedMessages = map[string]configspec.MessageRole{
 			"<name>": configspec.MessageRole_UNKNOWN_MESSAGE_ROLE,
 		}
 
-		_, err := unmarshalHandler(hnd)
+		_, err := unmarshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("returns an error if the produced messages are invalid", func() {
-		hnd.ProducedMessages = map[string]configspec.MessageRole{
+		handler.ProducedMessages = map[string]configspec.MessageRole{
 			"<name>": configspec.MessageRole_UNKNOWN_MESSAGE_ROLE,
 		}
 
-		_, err := unmarshalHandler(hnd)
+		_, err := unmarshalHandler(handler)
 		Expect(err).Should(HaveOccurred())
 	})
 })
@@ -181,7 +179,7 @@ var _ = Describe("func marshalNameRoles()", func() {
 
 	It("returns an error if the role can not be marshaled", func() {
 		in := message.NameRoles{
-			message.NameOf(MessageA{}): "<invalid>",
+			message.NameOf(fixtures.MessageA{}): "<invalid>",
 		}
 		_, err := marshalNameRoles(in)
 		Expect(err).Should(HaveOccurred())
@@ -210,7 +208,7 @@ var _ = Describe("func unmarshalNameRoles()", func() {
 
 var _ = Describe("func marshalIdentity()", func() {
 	It("returns the protobuf representation", func() {
-		in := configkit.MustNewIdentity("<name>", "9c71b756-b0ab-4c97-9ac8-75fae1dc8814")
+		in := MustNewIdentity("<name>", "9c71b756-b0ab-4c97-9ac8-75fae1dc8814")
 		out, err := marshalIdentity(in)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal(&configspec.Identity{
@@ -220,7 +218,7 @@ var _ = Describe("func marshalIdentity()", func() {
 	})
 
 	It("returns an error if the identity is invalid", func() {
-		in := configkit.Identity{}
+		in := Identity{}
 		_, err := marshalIdentity(in)
 		Expect(err).Should(HaveOccurred())
 	})
@@ -235,7 +233,7 @@ var _ = Describe("func unmarshalIdentity()", func() {
 		out, err := unmarshalIdentity(in)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal(
-			configkit.MustNewIdentity("<name>", "9a63e9ce-40ce-48a7-aa26-88b20a91ec61"),
+			MustNewIdentity("<name>", "9a63e9ce-40ce-48a7-aa26-88b20a91ec61"),
 		))
 	})
 
@@ -249,15 +247,15 @@ var _ = Describe("func unmarshalIdentity()", func() {
 var _ = Describe("func marshalHandlerType()", func() {
 	DescribeTable(
 		"returns the expected enumeration value",
-		func(in configkit.HandlerType, expect configspec.HandlerType) {
+		func(in HandlerType, expect configspec.HandlerType) {
 			out, err := marshalHandlerType(in)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(out).To(Equal(expect))
 		},
-		Entry("aggregate", configkit.AggregateHandlerType, configspec.HandlerType_AGGREGATE),
-		Entry("process", configkit.ProcessHandlerType, configspec.HandlerType_PROCESS),
-		Entry("integration", configkit.IntegrationHandlerType, configspec.HandlerType_INTEGRATION),
-		Entry("projection", configkit.ProjectionHandlerType, configspec.HandlerType_PROJECTION),
+		Entry("aggregate", AggregateHandlerType, configspec.HandlerType_AGGREGATE),
+		Entry("process", ProcessHandlerType, configspec.HandlerType_PROCESS),
+		Entry("integration", IntegrationHandlerType, configspec.HandlerType_INTEGRATION),
+		Entry("projection", ProjectionHandlerType, configspec.HandlerType_PROJECTION),
 	)
 
 	It("returns an error if the message role is invalid", func() {
@@ -269,15 +267,15 @@ var _ = Describe("func marshalHandlerType()", func() {
 var _ = Describe("func unmarshalHandlerType()", func() {
 	DescribeTable(
 		"returns the expected enumeration value",
-		func(in configspec.HandlerType, expect configkit.HandlerType) {
+		func(in configspec.HandlerType, expect HandlerType) {
 			out, err := unmarshalHandlerType(in)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(out).To(Equal(expect))
 		},
-		Entry("aggregate", configspec.HandlerType_AGGREGATE, configkit.AggregateHandlerType),
-		Entry("process", configspec.HandlerType_PROCESS, configkit.ProcessHandlerType),
-		Entry("integration", configspec.HandlerType_INTEGRATION, configkit.IntegrationHandlerType),
-		Entry("projection", configspec.HandlerType_PROJECTION, configkit.ProjectionHandlerType),
+		Entry("aggregate", configspec.HandlerType_AGGREGATE, AggregateHandlerType),
+		Entry("process", configspec.HandlerType_PROCESS, ProcessHandlerType),
+		Entry("integration", configspec.HandlerType_INTEGRATION, IntegrationHandlerType),
+		Entry("projection", configspec.HandlerType_PROJECTION, ProjectionHandlerType),
 	)
 
 	It("returns an error if the message role is invalid", func() {


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds functions converting application configurations to/from their protocol buffers representations.

#### Why make this change?

This behaviour was previously an internal implementation detail of the `api` package, but I needed the same functionality in `dogmatiq/browser`.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
