### PR TITLE
Fix panicking when handling type aliases in static analysis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.13.5] - 2024-08-16
+
+### Fixed
+
+- Fixed panicking when handling type aliases in static analysis.
+
 ## [0.13.4] - 2024-08-16
 
 ### Added
@@ -308,6 +314,7 @@ interfaces. It does not yet include support for static analysis of the new
 [0.13.2]: https://github.com/dogmatiq/configkit/releases/v0.13.2
 [0.13.3]: https://github.com/dogmatiq/configkit/releases/v0.13.3
 [0.13.4]: https://github.com/dogmatiq/configkit/releases/v0.13.4
+[0.13.5]: https://github.com/dogmatiq/configkit/releases/v0.13.5
 
 <!-- version template
 ## [0.0.1] - YYYY-MM-DD

--- a/static/adaptor_test.go
+++ b/static/adaptor_test.go
@@ -14,7 +14,7 @@ var _ = Describe("func FromPackages() (adaptor function)", func() {
 	When("the the handler is created by adapting a partial handler implementation", func() {
 		It("builds the configuration from the adapted type", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/handlers/adaptor",
 			}
 

--- a/static/adaptor_test.go
+++ b/static/adaptor_test.go
@@ -14,7 +14,7 @@ var _ = Describe("func FromPackages() (adaptor function)", func() {
 	When("the the handler is created by adapting a partial handler implementation", func() {
 		It("builds the configuration from the adapted type", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/handlers/adaptor",
 			}
 

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -462,6 +462,8 @@ func tryPkgOfNamedType(typ types.Type) (_ *types.Package, ok bool) {
 	switch t := typ.(type) {
 	case *types.Named:
 		return t.Obj().Pkg(), true
+	case *types.Alias:
+		return t.Obj().Pkg(), true
 	case *types.Pointer:
 		return tryPkgOfNamedType(t.Elem())
 	default:

--- a/static/analysis.go
+++ b/static/analysis.go
@@ -205,7 +205,7 @@ func addHandlerFromType(
 ) {
 	pkg := pkgOfNamedType(typ)
 	method := prog.LookupMethod(typ, pkg, "Configure")
-	addHandlerFromConfigureMethod(prog, method, hs, ht)
+	addHandlerFromConfigureMethod(prog, typ.String(), method, hs, ht)
 }
 
 // addHandlersFromAdaptorFunc analyzes the arguments of an "adaptor function" to
@@ -263,7 +263,7 @@ func addHandlersFromAdaptorFunc(
 			continue
 		}
 
-		addHandlerFromConfigureMethod(prog, method, hs, ht)
+		addHandlerFromConfigureMethod(prog, typ.String(), method, hs, ht)
 	}
 }
 
@@ -273,13 +273,14 @@ func addHandlersFromAdaptorFunc(
 // The handler configuration is added to hs.
 func addHandlerFromConfigureMethod(
 	prog *ssa.Program,
+	handlerType string,
 	method *ssa.Function,
 	hs configkit.HandlerSet,
 	ht configkit.HandlerType,
 ) {
 	hdr := &entity.Handler{
 		HandlerTypeValue: ht,
-		TypeNameValue:    method.Signature.Recv().Type().String(),
+		TypeNameValue:    handlerType,
 		MessageNamesValue: configkit.EntityMessageNames{
 			Produced: message.NameRoles{},
 			Consumed: message.NameRoles{},

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -14,7 +14,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a package contains a single application", func() {
 		It("returns the application configuration", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/single-app",
 			}
 
@@ -45,7 +45,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("multiple packages contain applications", func() {
 		It("returns all of the application configurations", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/multiple-apps-in-pkgs",
 			}
 
@@ -77,7 +77,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a single package contains multiple applications", func() {
 		It("returns all of the application configurations", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/multiple-apps-in-single-pkg/apps",
 			}
 
@@ -109,7 +109,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a package contains an application implemented with pointer receivers", func() {
 		It("returns the application configuration", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/pointer-receiver-app",
 			}
 
@@ -132,7 +132,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("none of the packages contain any applications", func() {
 		It("returns an empty slice", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/no-app",
 			}
 
@@ -147,7 +147,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a field within the application type is registered as a handler", func() {
 		It("includes the handler in the application configuration", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/handler-from-field",
 			}
 
@@ -172,7 +172,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("an application in the package has multiple handlers", func() {
 		It("returns all messages consumed or produced by all handlers", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/apps/app-level-messages",
 			}
 

--- a/static/app_test.go
+++ b/static/app_test.go
@@ -14,7 +14,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a package contains a single application", func() {
 		It("returns the application configuration", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/single-app",
 			}
 
@@ -45,7 +45,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("multiple packages contain applications", func() {
 		It("returns all of the application configurations", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/multiple-apps-in-pkgs",
 			}
 
@@ -77,7 +77,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a single package contains multiple applications", func() {
 		It("returns all of the application configurations", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/multiple-apps-in-single-pkg/apps",
 			}
 
@@ -109,7 +109,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a package contains an application implemented with pointer receivers", func() {
 		It("returns the application configuration", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/pointer-receiver-app",
 			}
 
@@ -132,7 +132,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("none of the packages contain any applications", func() {
 		It("returns an empty slice", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/no-app",
 			}
 
@@ -147,7 +147,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("a field within the application type is registered as a handler", func() {
 		It("includes the handler in the application configuration", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/handler-from-field",
 			}
 
@@ -172,7 +172,7 @@ var _ = Describe("func FromPackages() (application detection)", func() {
 	When("an application in the package has multiple handlers", func() {
 		It("returns all messages consumed or produced by all handlers", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/apps/app-level-messages",
 			}
 

--- a/static/constructor_test.go
+++ b/static/constructor_test.go
@@ -14,7 +14,7 @@ var _ = Describe("func FromPackages() (constructor function)", func() {
 	When("the handler is created by a call to a 'constructor' function", func() {
 		It("builds the configuration from the adapted type", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/handlers/constructor",
 			}
 

--- a/static/constructor_test.go
+++ b/static/constructor_test.go
@@ -14,7 +14,7 @@ var _ = Describe("func FromPackages() (constructor function)", func() {
 	When("the handler is created by a call to a 'constructor' function", func() {
 		It("builds the configuration from the adapted type", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/handlers/constructor",
 			}
 

--- a/static/handler_test.go
+++ b/static/handler_test.go
@@ -28,7 +28,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 	When("the application contains a single handler of each type", func() {
 		It("returns a single configuration for each handler type", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/handlers/single",
 			}
 
@@ -159,6 +159,8 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 			))
 		})
 		When("a handler is a type alias", func() {
+			goDbg := os.Getenv("GODEBUG")
+
 			BeforeEach(func() {
 				// Set the GODEBUG environment variable to enable type alias
 				// support.
@@ -170,12 +172,12 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 			})
 
 			AfterEach(func() {
-				os.Setenv("GODEBUG", "")
+				os.Setenv("GODEBUG", goDbg)
 			})
 
 			It("returns a single configuration for each handler type", func() {
 				cfg := packages.Config{
-					Mode: ConfigMode,
+					Mode: LoadPackagesConfigMode,
 					Dir:  "testdata/handlers/typealias",
 				}
 
@@ -199,7 +201,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 				)
 				Expect(aggregate.TypeName()).To(
 					Equal(
-						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.AggregateHandler",
+						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.AggregateHandlerAlias",
 					),
 				)
 				Expect(aggregate.HandlerType()).To(Equal(configkit.AggregateHandlerType))
@@ -228,7 +230,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 				)
 				Expect(process.TypeName()).To(
 					Equal(
-						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.ProcessHandler",
+						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.ProcessHandlerAlias",
 					),
 				)
 				Expect(process.HandlerType()).To(Equal(configkit.ProcessHandlerType))
@@ -261,7 +263,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 				)
 				Expect(projection.TypeName()).To(
 					Equal(
-						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.ProjectionHandler",
+						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.ProjectionHandlerAlias",
 					),
 				)
 				Expect(projection.HandlerType()).To(Equal(configkit.ProjectionHandlerType))
@@ -287,7 +289,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 				)
 				Expect(integration.TypeName()).To(
 					Equal(
-						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.IntegrationHandler",
+						"github.com/dogmatiq/configkit/static/testdata/handlers/typealias.IntergrationHandlerAlias",
 					),
 				)
 				Expect(integration.HandlerType()).To(Equal(configkit.IntegrationHandlerType))
@@ -310,7 +312,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 		When("messages are passed to the *Configurer.Routes() method", func() {
 			It("includes messages passed as args to *Configurer.Routes() method only", func() {
 				cfg := packages.Config{
-					Mode: ConfigMode,
+					Mode: LoadPackagesConfigMode,
 					Dir:  "testdata/handlers/only-routes-args",
 				}
 
@@ -445,7 +447,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 		When("messages are passed to the *Configurer.Routes() method as a dynamically populated splice", func() {
 			It("returns a single configuration for each handler type", func() {
 				cfg := packages.Config{
-					Mode: ConfigMode,
+					Mode: LoadPackagesConfigMode,
 					Dir:  "testdata/handlers/dynamic-routes",
 				}
 
@@ -580,7 +582,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 		When("messages are passed to the *Configurer.Routes() method in conditional branches", func() {
 			It("returns messages populated in every conditional branch", func() {
 				cfg := packages.Config{
-					Mode: ConfigMode,
+					Mode: LoadPackagesConfigMode,
 					Dir:  "testdata/handlers/conditional-branches",
 				}
 
@@ -715,7 +717,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 		When("nil is passed to a call of *Configurer.Routes() methods", func() {
 			It("does not populate messages", func() {
 				cfg := packages.Config{
-					Mode: ConfigMode,
+					Mode: LoadPackagesConfigMode,
 					Dir:  "testdata/handlers/nil-routes",
 				}
 
@@ -826,7 +828,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 	When("the application multiple handlers of each type", func() {
 		It("returns all of the handler configurations", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/handlers/multiple",
 			}
 
@@ -876,7 +878,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 	When("a nil value is passed as a handler", func() {
 		It("does not add a handler to the application configuration", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/handlers/nil-handler",
 			}
 
@@ -891,7 +893,7 @@ var _ = Describe("func FromPackages() (handler analysis)", func() {
 	When("a handler with a non-pointer methodset is registered as a pointer", func() {
 		It("includes the handler in the application configuration", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/handlers/pointer-handler-with-non-pointer-methodset",
 			}
 

--- a/static/ident_test.go
+++ b/static/ident_test.go
@@ -13,7 +13,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 	When("the identity is specified with non-literal constants", func() {
 		It("uses the values from the constants", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/ident/const-value-ident",
 			}
 
@@ -44,7 +44,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 	When("the identity is specified with string literals", func() {
 		It("uses the literal values", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/ident/literal-value-ident",
 			}
 
@@ -75,7 +75,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 	When("the identity is specified with non-constant expressions", func() {
 		It("uses a zero-value identity", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/ident/variable-value-ident",
 			}
 

--- a/static/ident_test.go
+++ b/static/ident_test.go
@@ -13,7 +13,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 	When("the identity is specified with non-literal constants", func() {
 		It("uses the values from the constants", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/ident/const-value-ident",
 			}
 
@@ -44,7 +44,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 	When("the identity is specified with string literals", func() {
 		It("uses the literal values", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/ident/literal-value-ident",
 			}
 
@@ -75,7 +75,7 @@ var _ = Describe("func FromPackages() (application identity)", func() {
 	When("the identity is specified with non-constant expressions", func() {
 		It("uses a zero-value identity", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/ident/variable-value-ident",
 			}
 

--- a/static/invalid_test.go
+++ b/static/invalid_test.go
@@ -11,7 +11,7 @@ var _ = Describe("func FromPackages() (unbuildable packages)", func() {
 	When("a package contains a file with invalid Go syntax", func() {
 		It("ignores the package", func() {
 			cfg := packages.Config{
-				Mode: ConfigMode,
+				Mode: LoadPackagesConfigMode,
 				Dir:  "testdata/invalid/invalid-syntax",
 			}
 

--- a/static/invalid_test.go
+++ b/static/invalid_test.go
@@ -11,7 +11,7 @@ var _ = Describe("func FromPackages() (unbuildable packages)", func() {
 	When("a package contains a file with invalid Go syntax", func() {
 		It("ignores the package", func() {
 			cfg := packages.Config{
-				Mode: packages.LoadAllSyntax,
+				Mode: ConfigMode,
 				Dir:  "testdata/invalid/invalid-syntax",
 			}
 

--- a/static/static.go
+++ b/static/static.go
@@ -9,6 +9,17 @@ import (
 	"golang.org/x/tools/go/ssa/ssautil"
 )
 
+// ConfigMode is the set of load mode values required to obtain the
+// information necessary to statically analyze Dogma applications.
+const ConfigMode = packages.NeedFiles |
+	packages.NeedCompiledGoFiles |
+	packages.NeedImports |
+	packages.NeedTypes |
+	packages.NeedTypesSizes |
+	packages.NeedSyntax |
+	packages.NeedTypesInfo |
+	packages.NeedDeps
+
 // FromPackages returns the configurations of the Dogma applications implemented
 // within a set of packages.
 //

--- a/static/static.go
+++ b/static/static.go
@@ -11,7 +11,7 @@ import (
 
 // ConfigMode is the set of load mode values required to obtain the
 // information necessary to statically analyze Dogma applications.
-const ConfigMode = packages.NeedFiles |
+const LoadPackagesConfigMode = packages.NeedFiles |
 	packages.NeedCompiledGoFiles |
 	packages.NeedImports |
 	packages.NeedTypes |

--- a/static/static.go
+++ b/static/static.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/go/ssa/ssautil"
 )
 
-// ConfigMode is the set of load mode values required to obtain the
+// LoadPackagesConfigMode is the set of load mode values required to obtain the
 // information necessary to statically analyze Dogma applications.
 const LoadPackagesConfigMode = packages.NeedFiles |
 	packages.NeedCompiledGoFiles |

--- a/static/testdata/handlers/typealias/aggregate.go
+++ b/static/testdata/handlers/typealias/aggregate.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Aggregate is an aggregate used for testing.
+type Aggregate struct{}
+
+// ApplyEvent updates the aggregate instance to reflect the occurrence of an
+// event that was recorded against this instance.
+func (Aggregate) ApplyEvent(dogma.Event) {}
+
+// AggregateHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateHandler struct{}
+
+// New returns a new account instance.
+func (AggregateHandler) New() dogma.AggregateRoot {
+	return Aggregate{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (AggregateHandler) Configure(c dogma.AggregateConfigurer) {
+	c.Identity("<aggregate>", "92623de9-c9cf-42f3-8338-33c50eeb06fb")
+
+	c.Routes(
+		dogma.HandlesCommand[fixtures.MessageA](),
+		dogma.HandlesCommand[fixtures.MessageB](),
+		dogma.RecordsEvent[fixtures.MessageC](),
+		dogma.RecordsEvent[fixtures.MessageD](),
+	)
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+func (AggregateHandler) RouteCommandToInstance(dogma.Command) string {
+	return "<aggregate>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (AggregateHandler) HandleCommand(
+	dogma.AggregateRoot,
+	dogma.AggregateCommandScope,
+	dogma.Command,
+) {
+}

--- a/static/testdata/handlers/typealias/app.go
+++ b/static/testdata/handlers/typealias/app.go
@@ -1,0 +1,28 @@
+package app
+
+import "github.com/dogmatiq/dogma"
+
+type (
+	// IntergrationHandlerAlias is a test type alias of IntegrationHandler.
+	IntergrationHandlerAlias = IntegrationHandler
+	// ProjectionHandlerAlias is a test type alias of ProjectionHandler.
+	ProjectionHandlerAlias = ProjectionHandler
+	// AggregateHandlerAlias is a test type alias of AggregateHandler.
+	AggregateHandlerAlias = AggregateHandler
+	// ProcessHandlerAlias is a test type alias of ProcessHandler.
+	ProcessHandlerAlias = ProcessHandler
+)
+
+// App implements dogma.Application interface.
+type App struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+func (App) Configure(c dogma.ApplicationConfigurer) {
+	c.Identity("<handler-as-typealias-app>", "1b828a1c-eba1-4e4c-88b8-e49f78ad15c7")
+
+	c.RegisterIntegration(IntergrationHandlerAlias{})
+	c.RegisterProjection(ProjectionHandlerAlias{})
+	c.RegisterAggregate(AggregateHandlerAlias{})
+	c.RegisterProcess(ProcessHandlerAlias{})
+}

--- a/static/testdata/handlers/typealias/integration.go
+++ b/static/testdata/handlers/typealias/integration.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// IntegrationHandler is a test implementation of
+// dogma.IntegrationMessageHandler.
+type IntegrationHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (IntegrationHandler) Configure(c dogma.IntegrationConfigurer) {
+	c.Identity("<integration>", "4d8cd3f5-21dc-475b-a8dc-80138adde3f2")
+
+	c.Routes(
+		dogma.HandlesCommand[fixtures.MessageA](),
+		dogma.HandlesCommand[fixtures.MessageB](),
+		dogma.RecordsEvent[fixtures.MessageC](),
+		dogma.RecordsEvent[fixtures.MessageD](),
+	)
+}
+
+// RouteCommandToInstance returns the ID of the integration instance that is
+// targetted by m.
+func (IntegrationHandler) RouteCommandToInstance(dogma.Command) string {
+	return "<integration>"
+}
+
+// HandleCommand handles a command message that has been routed to this handler.
+func (IntegrationHandler) HandleCommand(
+	context.Context,
+	dogma.IntegrationCommandScope,
+	dogma.Command,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (IntegrationHandler) TimeoutHint(dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/handlers/typealias/process.go
+++ b/static/testdata/handlers/typealias/process.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// Process is a process used for testing.
+type Process struct{}
+
+// ProcessHandler is a test implementation of dogma.ProcessMessageHandler.
+type ProcessHandler struct{}
+
+// New constructs a new process instance initialized with any default values and
+// returns the process root.
+func (ProcessHandler) New() dogma.ProcessRoot {
+	return Process{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (ProcessHandler) Configure(c dogma.ProcessConfigurer) {
+	c.Identity("<process>", "ad9d6955-893a-4d8d-a26e-e25886b113b2")
+
+	c.Routes(
+		dogma.HandlesEvent[fixtures.MessageA](),
+		dogma.HandlesEvent[fixtures.MessageB](),
+		dogma.ExecutesCommand[fixtures.MessageC](),
+		dogma.ExecutesCommand[fixtures.MessageD](),
+		dogma.SchedulesTimeout[fixtures.MessageE](),
+		dogma.SchedulesTimeout[fixtures.MessageF](),
+	)
+}
+
+// RouteEventToInstance returns the ID of the process instance that is
+// targeted by m.
+func (ProcessHandler) RouteEventToInstance(
+	context.Context,
+	dogma.Event,
+) (string, bool, error) {
+	return "<process>", true, nil
+}
+
+// HandleEvent handles an event message.
+func (ProcessHandler) HandleEvent(
+	context.Context,
+	dogma.ProcessRoot,
+	dogma.ProcessEventScope,
+	dogma.Event,
+) error {
+	return nil
+}
+
+// HandleTimeout handles a timeout message that has been scheduled with
+// ProcessScope.ScheduleTimeout().
+func (ProcessHandler) HandleTimeout(
+	context.Context,
+	dogma.ProcessRoot,
+	dogma.ProcessTimeoutScope,
+	dogma.Timeout,
+) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (ProcessHandler) TimeoutHint(dogma.Message) time.Duration {
+	return 0
+}

--- a/static/testdata/handlers/typealias/projection.go
+++ b/static/testdata/handlers/typealias/projection.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
+)
+
+// ProjectionHandler is a test implementation of dogma.ProjectionMessageHandler.
+type ProjectionHandler struct{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+func (ProjectionHandler) Configure(c dogma.ProjectionConfigurer) {
+	c.Identity("<projection>", "d012b7ed-3c4b-44db-9276-7bbc90fb54fd")
+
+	c.Routes(
+		dogma.HandlesEvent[fixtures.MessageA](),
+		dogma.HandlesEvent[fixtures.MessageB](),
+	)
+}
+
+// HandleEvent updates the projection to reflect the occurrence of an event.
+func (ProjectionHandler) HandleEvent(
+	_ context.Context,
+	_, _, _ []byte,
+	_ dogma.ProjectionEventScope,
+	_ dogma.Event,
+) (ok bool, err error) {
+	return false, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+func (ProjectionHandler) ResourceVersion(context.Context, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be
+// used in any future calls to HandleEvent().
+func (ProjectionHandler) CloseResource(context.Context, []byte) error {
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+func (ProjectionHandler) TimeoutHint(dogma.Message) time.Duration {
+	return 0
+}
+
+// Compact reduces the size of the projection's data.
+func (ProjectionHandler) Compact(context.Context, dogma.ProjectionCompactScope) error {
+	return nil
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This change is required to fix panicking when handling type aliases in static analysis. Type `types.Alias` is by default generated in Go 1.23 which wasn't handled properly before.

#### Why make this change?

To  fix panicking when handling type aliases in static analysis

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

N/A
